### PR TITLE
Add support for mapping claims to token metadatas

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -225,6 +225,16 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 			})
 		}
 	}
+	metadatas := map[string]string{
+		"role": roleName,
+	}
+	if ClaimsMapping := role.ClaimsToMetadatas; ClaimsMapping != nil {
+		for claimMapped, metaKey := range ClaimsMapping {
+			if c, ok := allClaims[claimMapped]; ok && metaKey != "" {
+				metadatas[metaKey] = fmt.Sprintf("%+v", c)
+			}
+		}
+	}
 
 	resp := &logical.Response{
 		Auth: &logical.Auth{
@@ -239,9 +249,7 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 			InternalData: map[string]interface{}{
 				"role": roleName,
 			},
-			Metadata: map[string]string{
-				"role": roleName,
-			},
+			Metadata: metadatas,
 			LeaseOptions: logical.LeaseOptions{
 				Renewable: true,
 				TTL:       role.TTL,

--- a/path_login.go
+++ b/path_login.go
@@ -231,7 +231,7 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 	if ClaimsMapping := role.ClaimsToMetadatas; ClaimsMapping != nil {
 		for claimMapped, metaKey := range ClaimsMapping {
 			if c, ok := allClaims[claimMapped]; ok && metaKey != "" {
-				metadatas[metaKey] = fmt.Sprintf("%+v", c)
+				metadatas[metaKey] = fmt.Sprintf("%v", c)
 			}
 		}
 	}

--- a/path_role.go
+++ b/path_role.go
@@ -197,7 +197,7 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 			"user_claim":                     role.UserClaim,
 			"groups_claim":                   role.GroupsClaim,
 			"groups_claim_delimiter_pattern": role.GroupsClaimDelimiterPattern,
-			"claims_to_metadata":             role.ClaimsToMetadatas,
+			"claims_to_metadatas":            role.ClaimsToMetadatas,
 		},
 	}
 

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -40,16 +40,17 @@ func TestPath_Create(t *testing.T) {
 	b, storage := getBackend(t)
 
 	data := map[string]interface{}{
-		"bound_subject":   "testsub",
-		"bound_audiences": "vault",
-		"user_claim":      "user",
-		"groups_claim":    "groups",
-		"bound_cidrs":     "127.0.0.1/8",
-		"policies":        "test",
-		"period":          "3s",
-		"ttl":             "1s",
-		"num_uses":        12,
-		"max_ttl":         "5s",
+		"bound_subject":       "testsub",
+		"bound_audiences":     "vault",
+		"user_claim":          "user",
+		"groups_claim":        "groups",
+		"bound_cidrs":         "127.0.0.1/8",
+		"policies":            "test",
+		"period":              "3s",
+		"ttl":                 "1s",
+		"num_uses":            12,
+		"max_ttl":             "5s",
+		"claims_to_metadatas": map[string]string{"key": "value"},
 	}
 
 	expectedSockAddr, err := sockaddr.NewSockAddr("127.0.0.1/8")
@@ -58,16 +59,17 @@ func TestPath_Create(t *testing.T) {
 	}
 
 	expected := &jwtRole{
-		Policies:       []string{"test"},
-		Period:         3 * time.Second,
-		BoundSubject:   "testsub",
-		BoundAudiences: []string{"vault"},
-		UserClaim:      "user",
-		GroupsClaim:    "groups",
-		TTL:            1 * time.Second,
-		MaxTTL:         5 * time.Second,
-		NumUses:        12,
-		BoundCIDRs:     []*sockaddr.SockAddrMarshaler{&sockaddr.SockAddrMarshaler{expectedSockAddr}},
+		Policies:          []string{"test"},
+		Period:            3 * time.Second,
+		BoundSubject:      "testsub",
+		BoundAudiences:    []string{"vault"},
+		UserClaim:         "user",
+		GroupsClaim:       "groups",
+		TTL:               1 * time.Second,
+		MaxTTL:            5 * time.Second,
+		NumUses:           12,
+		BoundCIDRs:        []*sockaddr.SockAddrMarshaler{&sockaddr.SockAddrMarshaler{expectedSockAddr}},
+		ClaimsToMetadatas: map[string]string{"key": "value"},
 	}
 
 	req := &logical.Request{
@@ -136,16 +138,17 @@ func TestPath_Read(t *testing.T) {
 	b, storage := getBackend(t)
 
 	data := map[string]interface{}{
-		"bound_subject":   "testsub",
-		"bound_audiences": "vault",
-		"user_claim":      "user",
-		"groups_claim":    "groups",
-		"bound_cidrs":     "127.0.0.1/8",
-		"policies":        "test",
-		"period":          "3s",
-		"ttl":             "1s",
-		"num_uses":        12,
-		"max_ttl":         "5s",
+		"bound_subject":       "testsub",
+		"bound_audiences":     "vault",
+		"user_claim":          "user",
+		"groups_claim":        "groups",
+		"bound_cidrs":         "127.0.0.1/8",
+		"policies":            "test",
+		"period":              "3s",
+		"ttl":                 "1s",
+		"num_uses":            12,
+		"max_ttl":             "5s",
+		"claims_to_metadatas": []string{"key=value"},
 	}
 
 	expected := map[string]interface{}{
@@ -159,6 +162,7 @@ func TestPath_Read(t *testing.T) {
 		"ttl":                            int64(1),
 		"num_uses":                       12,
 		"max_ttl":                        int64(5),
+		"claims_to_metadatas":            map[string]string{"key": "value"},
 	}
 
 	req := &logical.Request{


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/vault/issues/5477

This will let user specify a mapping as kv pairs between their JWT claims and returned token's metadatas.

This will be useful to add additional context from private Claims to existing tokens.
Same could be done with aliases I guess with another field to avoid stepping on each others.

### Disclaimer The name of the field is pretty bad, I wasn't really inspired.. let me know if you want me to change it  