### PR TITLE
Allow configuration of supported signing algorithms

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -36,7 +36,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 			"jwt_supported_algs": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: `A list of supported encoding algorithms. Defaults to empty, therefore the oidc plugin default, which currently is RS256 only.`,
+				Description: `A list of supported signing algorithms. Defaults to RS256.`,
 			},
 			"bound_issuer": {
 				Type:        framework.TypeString,

--- a/path_config.go
+++ b/path_config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"context"
@@ -32,6 +33,10 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "oidc_discovery_url".`,
+			},
+			"jwt_supported_algs": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `A list of supported encoding algorithms. Defaults to empty, therefore the oidc plugin default, which currently is RS256 only.`,
 			},
 			"bound_issuer": {
 				Type:        framework.TypeString,
@@ -99,6 +104,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"oidc_discovery_url":     config.OIDCDiscoveryURL,
 			"oidc_discovery_ca_pem":  config.OIDCDiscoveryCAPEM,
 			"jwt_validation_pubkeys": config.JWTValidationPubKeys,
+			"jwt_supported_algs":     config.JWTSupportedAlgs,
 			"bound_issuer":           config.BoundIssuer,
 		},
 	}
@@ -111,6 +117,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		OIDCDiscoveryURL:     d.Get("oidc_discovery_url").(string),
 		OIDCDiscoveryCAPEM:   d.Get("oidc_discovery_ca_pem").(string),
 		JWTValidationPubKeys: d.Get("jwt_validation_pubkeys").([]string),
+		JWTSupportedAlgs:     d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:          d.Get("bound_issuer").(string),
 	}
 
@@ -130,6 +137,15 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		for _, v := range config.JWTValidationPubKeys {
 			if _, err := certutil.ParsePublicKeyPEM([]byte(v)); err != nil {
 				return logical.ErrorResponse(errwrap.Wrapf("error parsing public key: {{err}}", err).Error()), nil
+			}
+		}
+
+	case len(config.JWTSupportedAlgs) != 0:
+		for _, a := range config.JWTSupportedAlgs {
+			switch a {
+			case oidc.RS256, oidc.RS384, oidc.RS512, oidc.ES256, oidc.ES384, oidc.ES512, oidc.PS256, oidc.PS384, oidc.PS512:
+			default:
+				return logical.ErrorResponse(fmt.Sprintf("Invalid supported algorithm: %s", a)), nil
 			}
 		}
 
@@ -182,6 +198,7 @@ type jwtConfig struct {
 	OIDCDiscoveryURL     string   `json:"oidc_discovery_url"`
 	OIDCDiscoveryCAPEM   string   `json:"oidc_discovery_ca_pem"`
 	JWTValidationPubKeys []string `json:"jwt_validation_pubkeys"`
+	JWTSupportedAlgs     []string `json:"jwt_supported_algs"`
 	BoundIssuer          string   `json:"bound_issuer"`
 
 	ParsedJWTPubKeys []interface{} `json:"-"`

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -18,6 +18,7 @@ func TestConfig_JWT_Read(t *testing.T) {
 		"oidc_discovery_url":     "",
 		"oidc_discovery_ca_pem":  "",
 		"jwt_validation_pubkeys": []string{testJWTPubKey},
+		"jwt_supported_algs":     []string{},
 		"bound_issuer":           "http://vault.example.com/",
 	}
 
@@ -96,6 +97,7 @@ func TestConfig_JWT_Write(t *testing.T) {
 	expected := &jwtConfig{
 		ParsedJWTPubKeys:     []interface{}{pubkey},
 		JWTValidationPubKeys: []string{testJWTPubKey},
+		JWTSupportedAlgs:     []string{},
 		BoundIssuer:          "http://vault.example.com/",
 	}
 
@@ -142,6 +144,7 @@ func TestConfig_OIDC_Write(t *testing.T) {
 
 	expected := &jwtConfig{
 		JWTValidationPubKeys: []string{},
+		JWTSupportedAlgs:     []string{},
 		OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
 	}
 

--- a/path_login.go
+++ b/path_login.go
@@ -136,7 +136,8 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		}
 
 		verifier := provider.Verifier(&oidc.Config{
-			SkipClientIDCheck: true,
+			SkipClientIDCheck:    true,
+			SupportedSigningAlgs: config.JWTSupportedAlgs,
 		})
 
 		idToken, err := verifier.Verify(ctx, token)


### PR DESCRIPTION
By default, only RS256 is supported.  We use RS512 for our JWT service, so we'd prefer to default to both being available.