### PR TITLE
JWT metadata update from claims

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -245,6 +245,14 @@
   revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
+  branch = "master"
+  digest = "1:302de3c669b04a566d4e99760d6fb35a22177fc14c7a9284e8b3cf6e9fe3f28a"
+  name = "github.com/mitchellh/pointerstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f2329fcfa9e280bdb5a3f2544aec815a508ad72f"
+
+[[projects]]
   digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
   name = "github.com/oklog/run"
   packages = ["."]
@@ -455,6 +463,7 @@
     "github.com/hashicorp/vault/logical",
     "github.com/hashicorp/vault/logical/framework",
     "github.com/hashicorp/vault/logical/plugin",
+    "github.com/mitchellh/pointerstructure",
     "golang.org/x/oauth2",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/square/go-jose.v2/jwt",

--- a/claims.go
+++ b/claims.go
@@ -1,0 +1,47 @@
+package jwtauth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/pointerstructure"
+)
+
+// getClaim returns a claim value from allClaims given a provided claim string.
+// If this string is a valid JSONPointer, it will be interpreted as such to locate
+// the claim. Otherwise, the claim string will be used directly.
+func getClaim(allClaims map[string]interface{}, claim string) interface{} {
+	if !strings.HasPrefix(claim, "/") {
+		return allClaims[claim]
+	}
+
+	val, err := pointerstructure.Get(allClaims, claim)
+	if err != nil {
+		return nil
+	}
+
+	return val
+}
+
+// extractMetadata builds a metadata map from a set of claims and claims mappings.
+// The referenced claims must be strings and the claims mappings must be of the structure:
+//
+//   {
+//       "/some/claim/pointer": "metadata_key1",
+//       "another_claim": "metadata_key2",
+//        ...
+//   }
+func extractMetadata(allClaims map[string]interface{}, claimMappings map[string]string) (map[string]string, error) {
+	metadata := make(map[string]string)
+	for source, target := range claimMappings {
+		if value := getClaim(allClaims, source); value != nil {
+			strValue, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("error converting claim '%s' to string", source)
+			}
+
+			metadata[target] = strValue
+		}
+	}
+	return metadata, nil
+}

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,0 +1,136 @@
+package jwtauth
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestGetClaim(t *testing.T) {
+	tests := []struct {
+		allClaims map[string]interface{}
+		claim     string
+		expected  interface{}
+	}{
+		{nil, "data", nil},
+		{map[string]interface{}{"data": "foo"}, "data", "foo"},
+		{map[string]interface{}{"data": "foo"}, "data2", nil},
+		{map[string]interface{}{"data": "foo"}, "/data", "foo"},
+		{
+			map[string]interface{}{"data": map[string]interface{}{
+				"foo": "bar",
+			}}, "/data/foo", "bar",
+		},
+		{
+			map[string]interface{}{"data": map[string]interface{}{
+				"foo": "bar",
+			}}, "/data/foo2", nil,
+		},
+
+		{map[string]interface{}{"data": "foo"}, `\`, nil},
+	}
+
+	for _, test := range tests {
+		actual := getClaim(test.allClaims, test.claim)
+		if diff := deep.Equal(actual, test.expected); diff != nil {
+			t.Fatalf("invalid results for claim '%s': %v", test.claim, diff)
+		}
+	}
+}
+
+func TestExtractMetadata(t *testing.T) {
+	emptyMap := make(map[string]string)
+
+	tests := []struct {
+		testCase      string
+		allClaims     map[string]interface{}
+		claimMappings map[string]string
+		expected      map[string]string
+		errExpected   bool
+	}{
+		{"empty", nil, nil, emptyMap, false},
+		{
+			"full match",
+			map[string]interface{}{
+				"data1": "foo",
+				"data2": "bar",
+			},
+			map[string]string{
+				"data1": "val1",
+				"data2": "val2",
+			},
+			map[string]string{
+				"val1": "foo",
+				"val2": "bar",
+			},
+			false,
+		},
+		{
+			"partial match",
+			map[string]interface{}{
+				"data1": "foo",
+				"data2": "bar",
+			},
+			map[string]string{
+				"data1": "val1",
+				"data3": "val2",
+			},
+			map[string]string{
+				"val1": "foo",
+			},
+			false,
+		},
+		{
+			"no match",
+			map[string]interface{}{
+				"data1": "foo",
+				"data2": "bar",
+			},
+			map[string]string{
+				"data8": "val1",
+				"data9": "val2",
+			},
+			emptyMap,
+			false,
+		},
+		{
+			"nested data",
+			map[string]interface{}{
+				"data1": "foo",
+				"data2": map[string]interface{}{
+					"child": "bar",
+				},
+			},
+			map[string]string{
+				"data1":        "val1",
+				"/data2/child": "val2",
+			},
+			map[string]string{
+				"val1": "foo",
+				"val2": "bar",
+			},
+			false,
+		},
+		{
+			"error: non-string data",
+			map[string]interface{}{
+				"data1": 42,
+			},
+			map[string]string{
+				"data1": "val1",
+			},
+			nil,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := extractMetadata(test.allClaims, test.claimMappings)
+		if (err != nil) != test.errExpected {
+			t.Fatalf("case '%s': expected error: %t, actual: %v", test.testCase, test.errExpected, err)
+		}
+		if diff := deep.Equal(actual, test.expected); diff != nil {
+			t.Fatalf("case '%s': expected results: %v", test.testCase, diff)
+		}
+	}
+}

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -264,9 +264,8 @@ func TestLogin_JWT(t *testing.T) {
 			t.Fatal(diff)
 		}
 
-		// check alias metadata
+		// check token metadata
 		metadata["role"] = "plugin-test"
-
 		if diff := deep.Equal(auth.Metadata, metadata); diff != nil {
 			t.Fatal(diff)
 		}

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -3,7 +3,6 @@ package jwtauth
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -261,20 +260,19 @@ func TestPath_Read(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"role_type":                      "jwt",
-		"bound_claims":                   map[string]interface{}(nil),
-		"claim_mappings":                 map[string]string(nil),
-		"bound_subject":                  "testsub",
-		"bound_audiences":                []string{"vault"},
-		"allowed_redirect_uris":          []string(nil),
-		"user_claim":                     "user",
-		"groups_claim":                   "groups",
-		"groups_claim_delimiter_pattern": "",
-		"policies":                       []string{"test"},
-		"period":                         int64(3),
-		"ttl":                            int64(1),
-		"num_uses":                       12,
-		"max_ttl":                        int64(5),
+		"role_type":             "jwt",
+		"bound_claims":          map[string]interface{}(nil),
+		"claim_mappings":        map[string]string(nil),
+		"bound_subject":         "testsub",
+		"bound_audiences":       []string{"vault"},
+		"allowed_redirect_uris": []string(nil),
+		"user_claim":            "user",
+		"groups_claim":          "groups",
+		"policies":              []string{"test"},
+		"period":                int64(3),
+		"ttl":                   int64(1),
+		"num_uses":              12,
+		"max_ttl":               int64(5),
 	}
 
 	req := &logical.Request{
@@ -365,69 +363,5 @@ func TestPath_Delete(t *testing.T) {
 
 	if resp != nil {
 		t.Fatalf("Unexpected resp data: expected nil got %#v\n", resp.Data)
-	}
-}
-
-func TestParseClaimWithDelimiters(t *testing.T) {
-	type tc struct {
-		name string
-		c    string
-		d    string
-		res  []string
-		err  error
-	}
-
-	testCases := []tc{
-		{
-			name: "nodelim",
-			c:    "groups",
-			res:  []string{"groups"},
-		},
-		{
-			name: "multi",
-			c:    "gr.o/u.ps",
-			d:    "./.",
-			res:  []string{"gr", "o", "u", "ps"},
-		},
-		{
-			name: "multiextradelims",
-			c:    "gr.o/u.ps",
-			d:    "./..",
-			err:  errors.New(`could not find instance of "." delimiter in claim`),
-		},
-		{
-			name: "delimnotfound",
-			c:    "groups",
-			d:    ".",
-			err:  errors.New(`could not find instance of "." delimiter in claim`),
-		},
-		{
-			name: "delimatend",
-			c:    "groups.",
-			d:    ".",
-			err:  errors.New(`instance of "." delimiter in claim is at end of claim string`),
-		},
-		{
-			name: "delimatbeginning",
-			c:    ".groups",
-			d:    ".",
-			err:  errors.New(`instance of "." delimiter in claim is at beginning of claim string`),
-		},
-		{
-			name: "backtoback",
-			c:    "gro/.ups",
-			d:    "/.",
-			err:  errors.New(`instance of "." delimiter in claim is at beginning of claim string`),
-		},
-	}
-
-	for _, testCase := range testCases {
-		ret, err := parseClaimWithDelimiters(testCase.c, testCase.d)
-		if diff := deep.Equal(testCase.err, err); diff != nil {
-			t.Fatalf("%s: %v", testCase.name, diff)
-		}
-		if diff := deep.Equal(testCase.res, ret); diff != nil {
-			t.Fatalf("%s: %v", testCase.name, diff)
-		}
 	}
 }

--- a/vendor/github.com/mitchellh/pointerstructure/.travis.yml
+++ b/vendor/github.com/mitchellh/pointerstructure/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+    - 1.7
+    - tip
+
+script:
+    - go test
+
+matrix:
+    allow_failures:
+        - go: tip

--- a/vendor/github.com/mitchellh/pointerstructure/README.md
+++ b/vendor/github.com/mitchellh/pointerstructure/README.md
@@ -1,0 +1,74 @@
+# pointerstructure [![GoDoc](https://godoc.org/github.com/mitchellh/pointerstructure?status.svg)](https://godoc.org/github.com/mitchellh/pointerstructure)
+
+pointerstructure is a Go library for identifying a specific value within
+any Go structure using a string syntax.
+
+pointerstructure is based on
+[JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901), but
+reimplemented for Go.
+
+The goal of pointerstructure is to provide a single, well-known format
+for addressing a specific value. This can be useful for user provided
+input on structures, diffs of structures, etc.
+
+## Features
+
+  * Get the value for an address
+
+  * Set the value for an address within an existing structure
+
+  * Delete the value at an address
+
+  * Sorting a list of addresses
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/pointerstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/pointerstructure).
+
+A quick code example is shown below:
+
+```go
+complex := map[string]interface{}{
+	"alice": 42,
+	"bob": []interface{}{
+		map[string]interface{}{
+			"name": "Bob",
+		},
+	},
+}
+
+value, err := pointerstructure.Get(complex, "/bob/0/name")
+if err != nil {
+	panic(err)
+}
+
+fmt.Printf("%s", value)
+// Output:
+// Bob
+```
+
+Continuing the example above, you can also set values:
+
+```go
+value, err = pointerstructure.Set(complex, "/bob/0/name", "Alice")
+if err != nil {
+	panic(err)
+}
+
+value, err = pointerstructure.Get(complex, "/bob/0/name")
+if err != nil {
+	panic(err)
+}
+
+fmt.Printf("%s", value)
+// Output:
+// Alice
+```

--- a/vendor/github.com/mitchellh/pointerstructure/delete.go
+++ b/vendor/github.com/mitchellh/pointerstructure/delete.go
@@ -1,0 +1,112 @@
+package pointerstructure
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Delete deletes the value specified by the pointer p in structure s.
+//
+// When deleting a slice index, all other elements will be shifted to
+// the left. This is specified in RFC6902 (JSON Patch) and not RFC6901 since
+// RFC6901 doesn't specify operations on pointers. If you don't want to
+// shift elements, you should use Set to set the slice index to the zero value.
+//
+// The structures s must have non-zero values set up to this pointer.
+// For example, if deleting "/bob/0/name", then "/bob/0" must be set already.
+//
+// The returned value is potentially a new value if this pointer represents
+// the root document. Otherwise, the returned value will always be s.
+func (p *Pointer) Delete(s interface{}) (interface{}, error) {
+	// if we represent the root doc, we've deleted everything
+	if len(p.Parts) == 0 {
+		return nil, nil
+	}
+
+	// Save the original since this is going to be our return value
+	originalS := s
+
+	// Get the parent value
+	var err error
+	s, err = p.Parent().Get(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map for lookup of getter to call for type
+	funcMap := map[reflect.Kind]deleteFunc{
+		reflect.Array: p.deleteSlice,
+		reflect.Map:   p.deleteMap,
+		reflect.Slice: p.deleteSlice,
+	}
+
+	val := reflect.ValueOf(s)
+	for val.Kind() == reflect.Interface {
+		val = val.Elem()
+	}
+
+	for val.Kind() == reflect.Ptr {
+		val = reflect.Indirect(val)
+	}
+
+	f, ok := funcMap[val.Kind()]
+	if !ok {
+		return nil, fmt.Errorf("delete %s: invalid value kind: %s", p, val.Kind())
+	}
+
+	result, err := f(originalS, val)
+	if err != nil {
+		return nil, fmt.Errorf("delete %s: %s", p, err)
+	}
+
+	return result, nil
+}
+
+type deleteFunc func(interface{}, reflect.Value) (interface{}, error)
+
+func (p *Pointer) deleteMap(root interface{}, m reflect.Value) (interface{}, error) {
+	part := p.Parts[len(p.Parts)-1]
+	key, err := coerce(reflect.ValueOf(part), m.Type().Key())
+	if err != nil {
+		return root, err
+	}
+
+	// Delete the key
+	var elem reflect.Value
+	m.SetMapIndex(key, elem)
+	return root, nil
+}
+
+func (p *Pointer) deleteSlice(root interface{}, s reflect.Value) (interface{}, error) {
+	// Coerce the key to an int
+	part := p.Parts[len(p.Parts)-1]
+	idxVal, err := coerce(reflect.ValueOf(part), reflect.TypeOf(42))
+	if err != nil {
+		return root, err
+	}
+	idx := int(idxVal.Int())
+
+	// Verify we're within bounds
+	if idx < 0 || idx >= s.Len() {
+		return root, fmt.Errorf(
+			"index %d is out of range (length = %d)", idx, s.Len())
+	}
+
+	// Mimicing the following with reflection to do this:
+	//
+	// copy(a[i:], a[i+1:])
+	// a[len(a)-1] = nil // or the zero value of T
+	// a = a[:len(a)-1]
+
+	// copy(a[i:], a[i+1:])
+	reflect.Copy(s.Slice(idx, s.Len()), s.Slice(idx+1, s.Len()))
+
+	// a[len(a)-1] = nil // or the zero value of T
+	s.Index(s.Len() - 1).Set(reflect.Zero(s.Type().Elem()))
+
+	// a = a[:len(a)-1]
+	s = s.Slice(0, s.Len()-1)
+
+	// set the slice back on the parent
+	return p.Parent().Set(root, s.Interface())
+}

--- a/vendor/github.com/mitchellh/pointerstructure/get.go
+++ b/vendor/github.com/mitchellh/pointerstructure/get.go
@@ -1,0 +1,91 @@
+package pointerstructure
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Get reads the value out of the total value v.
+func (p *Pointer) Get(v interface{}) (interface{}, error) {
+	// fast-path the empty address case to avoid reflect.ValueOf below
+	if len(p.Parts) == 0 {
+		return v, nil
+	}
+
+	// Map for lookup of getter to call for type
+	funcMap := map[reflect.Kind]func(string, reflect.Value) (reflect.Value, error){
+		reflect.Array: p.getSlice,
+		reflect.Map:   p.getMap,
+		reflect.Slice: p.getSlice,
+	}
+
+	currentVal := reflect.ValueOf(v)
+	for i, part := range p.Parts {
+		for currentVal.Kind() == reflect.Interface {
+			currentVal = currentVal.Elem()
+		}
+
+		for currentVal.Kind() == reflect.Ptr {
+			currentVal = reflect.Indirect(currentVal)
+		}
+
+		f, ok := funcMap[currentVal.Kind()]
+		if !ok {
+			return nil, fmt.Errorf(
+				"%s: at part %d, invalid value kind: %s", p, i, currentVal.Kind())
+		}
+
+		var err error
+		currentVal, err = f(part, currentVal)
+		if err != nil {
+			return nil, fmt.Errorf("%s at part %d: %s", p, i, err)
+		}
+	}
+
+	return currentVal.Interface(), nil
+}
+
+func (p *Pointer) getMap(part string, m reflect.Value) (reflect.Value, error) {
+	var zeroValue reflect.Value
+
+	// Coerce the string part to the correct key type
+	key, err := coerce(reflect.ValueOf(part), m.Type().Key())
+	if err != nil {
+		return zeroValue, err
+	}
+
+	// Verify that the key exists
+	found := false
+	for _, k := range m.MapKeys() {
+		if k.Interface() == key.Interface() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return zeroValue, fmt.Errorf("couldn't find key %#v", key.Interface())
+	}
+
+	// Get the key
+	return m.MapIndex(key), nil
+}
+
+func (p *Pointer) getSlice(part string, v reflect.Value) (reflect.Value, error) {
+	var zeroValue reflect.Value
+
+	// Coerce the key to an int
+	idxVal, err := coerce(reflect.ValueOf(part), reflect.TypeOf(42))
+	if err != nil {
+		return zeroValue, err
+	}
+	idx := int(idxVal.Int())
+
+	// Verify we're within bounds
+	if idx < 0 || idx >= v.Len() {
+		return zeroValue, fmt.Errorf(
+			"index %d is out of range (length = %d)", idx, v.Len())
+	}
+
+	// Get the key
+	return v.Index(idx), nil
+}

--- a/vendor/github.com/mitchellh/pointerstructure/parse.go
+++ b/vendor/github.com/mitchellh/pointerstructure/parse.go
@@ -1,0 +1,57 @@
+package pointerstructure
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Parse parses a pointer from the input string. The input string
+// is expected to follow the format specified by RFC 6901: '/'-separated
+// parts. Each part can contain escape codes to contain '/' or '~'.
+func Parse(input string) (*Pointer, error) {
+	// Special case the empty case
+	if input == "" {
+		return &Pointer{}, nil
+	}
+
+	// We expect the first character to be "/"
+	if input[0] != '/' {
+		return nil, fmt.Errorf(
+			"parse Go pointer %q: first char must be '/'", input)
+	}
+
+	// Trim out the first slash so we don't have to +1 every index
+	input = input[1:]
+
+	// Parse out all the parts
+	var parts []string
+	lastSlash := -1
+	for i, r := range input {
+		if r == '/' {
+			parts = append(parts, input[lastSlash+1:i])
+			lastSlash = i
+		}
+	}
+
+	// Add last part
+	parts = append(parts, input[lastSlash+1:])
+
+	// Process each part for string replacement
+	for i, p := range parts {
+		// Replace ~1 followed by ~0 as specified by the RFC
+		parts[i] = strings.Replace(
+			strings.Replace(p, "~1", "/", -1), "~0", "~", -1)
+	}
+
+	return &Pointer{Parts: parts}, nil
+}
+
+// MustParse is like Parse but panics if the input cannot be parsed.
+func MustParse(input string) *Pointer {
+	p, err := Parse(input)
+	if err != nil {
+		panic(err)
+	}
+
+	return p
+}

--- a/vendor/github.com/mitchellh/pointerstructure/pointer.go
+++ b/vendor/github.com/mitchellh/pointerstructure/pointer.go
@@ -1,0 +1,123 @@
+// Package pointerstructure provides functions for identifying a specific
+// value within any Go structure using a string syntax.
+//
+// The syntax used is based on JSON Pointer (RFC 6901).
+package pointerstructure
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// Pointer represents a pointer to a specific value. You can construct
+// a pointer manually or use Parse.
+type Pointer struct {
+	// Parts are the pointer parts. No escape codes are processed here.
+	// The values are expected to be exact. If you have escape codes, use
+	// the Parse functions.
+	Parts []string
+}
+
+// Get reads the value at the given pointer.
+//
+// This is a shorthand for calling Parse on the pointer and then calling Get
+// on that result. An error will be returned if the value cannot be found or
+// there is an error with the format of pointer.
+func Get(value interface{}, pointer string) (interface{}, error) {
+	p, err := Parse(pointer)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Get(value)
+}
+
+// Set sets the value at the given pointer.
+//
+// This is a shorthand for calling Parse on the pointer and then calling Set
+// on that result. An error will be returned if the value cannot be found or
+// there is an error with the format of pointer.
+//
+// Set returns the complete document, which might change if the pointer value
+// points to the root ("").
+func Set(doc interface{}, pointer string, value interface{}) (interface{}, error) {
+	p, err := Parse(pointer)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Set(doc, value)
+}
+
+// String returns the string value that can be sent back to Parse to get
+// the same Pointer result.
+func (p *Pointer) String() string {
+	if len(p.Parts) == 0 {
+		return ""
+	}
+
+	// Copy the parts so we can convert back the escapes
+	result := make([]string, len(p.Parts))
+	copy(result, p.Parts)
+	for i, p := range p.Parts {
+		result[i] = strings.Replace(
+			strings.Replace(p, "~", "~0", -1), "/", "~1", -1)
+
+	}
+
+	return "/" + strings.Join(result, "/")
+}
+
+// Parent returns a pointer to the parent element of this pointer.
+//
+// If Pointer represents the root (empty parts), a pointer representing
+// the root is returned. Therefore, to check for the root, IsRoot() should be
+// called.
+func (p *Pointer) Parent() *Pointer {
+	// If this is root, then we just return a new root pointer. We allocate
+	// a new one though so this can still be modified.
+	if p.IsRoot() {
+		return &Pointer{}
+	}
+
+	parts := make([]string, len(p.Parts)-1)
+	copy(parts, p.Parts[:len(p.Parts)-1])
+	return &Pointer{
+		Parts: parts,
+	}
+}
+
+// IsRoot returns true if this pointer represents the root document.
+func (p *Pointer) IsRoot() bool {
+	return len(p.Parts) == 0
+}
+
+// coerce is a helper to coerce a value to a specific type if it must
+// and if its possible. If it isn't possible, an error is returned.
+func coerce(value reflect.Value, to reflect.Type) (reflect.Value, error) {
+	// If the value is already assignable to the type, then let it go
+	if value.Type().AssignableTo(to) {
+		return value, nil
+	}
+
+	// If a direct conversion is possible, do that
+	if value.Type().ConvertibleTo(to) {
+		return value.Convert(to), nil
+	}
+
+	// Create a new value to hold our result
+	result := reflect.New(to)
+
+	// Decode
+	if err := mapstructure.WeakDecode(value.Interface(), result.Interface()); err != nil {
+		return result, fmt.Errorf(
+			"couldn't convert value %#v to type %s",
+			value.Interface(), to.String())
+	}
+
+	// We need to indirect the value since reflect.New always creates a pointer
+	return reflect.Indirect(result), nil
+}

--- a/vendor/github.com/mitchellh/pointerstructure/set.go
+++ b/vendor/github.com/mitchellh/pointerstructure/set.go
@@ -1,0 +1,122 @@
+package pointerstructure
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Set writes a value v to the pointer p in structure s.
+//
+// The structures s must have non-zero values set up to this pointer.
+// For example, if setting "/bob/0/name", then "/bob/0" must be set already.
+//
+// The returned value is potentially a new value if this pointer represents
+// the root document. Otherwise, the returned value will always be s.
+func (p *Pointer) Set(s, v interface{}) (interface{}, error) {
+	// if we represent the root doc, return that
+	if len(p.Parts) == 0 {
+		return v, nil
+	}
+
+	// Save the original since this is going to be our return value
+	originalS := s
+
+	// Get the parent value
+	var err error
+	s, err = p.Parent().Get(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map for lookup of getter to call for type
+	funcMap := map[reflect.Kind]setFunc{
+		reflect.Array: p.setSlice,
+		reflect.Map:   p.setMap,
+		reflect.Slice: p.setSlice,
+	}
+
+	val := reflect.ValueOf(s)
+	for val.Kind() == reflect.Interface {
+		val = val.Elem()
+	}
+
+	for val.Kind() == reflect.Ptr {
+		val = reflect.Indirect(val)
+	}
+
+	f, ok := funcMap[val.Kind()]
+	if !ok {
+		return nil, fmt.Errorf("set %s: invalid value kind: %s", p, val.Kind())
+	}
+
+	result, err := f(originalS, val, reflect.ValueOf(v))
+	if err != nil {
+		return nil, fmt.Errorf("set %s: %s", p, err)
+	}
+
+	return result, nil
+}
+
+type setFunc func(interface{}, reflect.Value, reflect.Value) (interface{}, error)
+
+func (p *Pointer) setMap(root interface{}, m, value reflect.Value) (interface{}, error) {
+	part := p.Parts[len(p.Parts)-1]
+	key, err := coerce(reflect.ValueOf(part), m.Type().Key())
+	if err != nil {
+		return root, err
+	}
+
+	elem, err := coerce(value, m.Type().Elem())
+	if err != nil {
+		return root, err
+	}
+
+	// Set the key
+	m.SetMapIndex(key, elem)
+	return root, nil
+}
+
+func (p *Pointer) setSlice(root interface{}, s, value reflect.Value) (interface{}, error) {
+	// Coerce the value, we'll need that no matter what
+	value, err := coerce(value, s.Type().Elem())
+	if err != nil {
+		return root, err
+	}
+
+	// If the part is the special "-", that means to append it (RFC6901 4.)
+	part := p.Parts[len(p.Parts)-1]
+	if part == "-" {
+		return p.setSliceAppend(root, s, value)
+	}
+
+	// Coerce the key to an int
+	idxVal, err := coerce(reflect.ValueOf(part), reflect.TypeOf(42))
+	if err != nil {
+		return root, err
+	}
+	idx := int(idxVal.Int())
+
+	// Verify we're within bounds
+	if idx < 0 || idx >= s.Len() {
+		return root, fmt.Errorf(
+			"index %d is out of range (length = %d)", idx, s.Len())
+	}
+
+	// Set the key
+	s.Index(idx).Set(value)
+	return root, nil
+}
+
+func (p *Pointer) setSliceAppend(root interface{}, s, value reflect.Value) (interface{}, error) {
+	// Coerce the value, we'll need that no matter what. This should
+	// be a no-op since we expect it to be done already, but there is
+	// a fast-path check for that in coerce so do it anyways.
+	value, err := coerce(value, s.Type().Elem())
+	if err != nil {
+		return root, err
+	}
+
+	// We can assume "s" is the parent of pointer value. We need to actually
+	// write s back because Append can return a new slice.
+	return p.Parent().Set(root, reflect.Append(s, value).Interface())
+}

--- a/vendor/github.com/mitchellh/pointerstructure/sort.go
+++ b/vendor/github.com/mitchellh/pointerstructure/sort.go
@@ -1,0 +1,42 @@
+package pointerstructure
+
+import (
+	"sort"
+)
+
+// Sort does an in-place sort of the pointers so that they are in order
+// of least specific to most specific alphabetized. For example:
+// "/foo", "/foo/0", "/qux"
+//
+// This ordering is ideal for applying the changes in a way that ensures
+// that parents are set first.
+func Sort(p []*Pointer) { sort.Sort(PointerSlice(p)) }
+
+// PointerSlice is a slice of pointers that adheres to sort.Interface
+type PointerSlice []*Pointer
+
+func (p PointerSlice) Len() int      { return len(p) }
+func (p PointerSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p PointerSlice) Less(i, j int) bool {
+	// Equal number of parts, do a string compare per part
+	for idx, ival := range p[i].Parts {
+		// If we're passed the length of p[j] parts, then we're done
+		if idx >= len(p[j].Parts) {
+			break
+		}
+
+		// Compare the values if they're not equal
+		jval := p[j].Parts[idx]
+		if ival != jval {
+			return ival < jval
+		}
+	}
+
+	// Equal prefix, take the shorter
+	if len(p[i].Parts) != len(p[j].Parts) {
+		return len(p[i].Parts) < len(p[j].Parts)
+	}
+
+	// Equal, it doesn't matter
+	return false
+}


### PR DESCRIPTION
This PR also removes the groupClaimsDelimiter approach to specifying
the location of nested claims data. JSONPointer is used instead.