### PR TITLE
Add OIDC callback handler

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -51,6 +51,9 @@ func backend(c *logical.BackendConfig) *jwtAuthBackend {
 			Unauthenticated: []string{
 				"login",
 				"oidc/auth_url",
+				"oidc/callback",
+				"ui", // TODO: remove when Vault UI is ready
+
 			},
 			SealWrapStorage: []string{
 				"config",
@@ -62,6 +65,7 @@ func backend(c *logical.BackendConfig) *jwtAuthBackend {
 				pathRoleList(b),
 				pathRole(b),
 				pathConfig(b),
+				pathUI(b), // TODO: remove when Vault UI is ready
 			},
 			pathOIDC(b),
 		),

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,39 +1,56 @@
 package jwtauth
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/go-test/deep"
 )
 
 func TestGetClaim(t *testing.T) {
-	tests := []struct {
-		allClaims map[string]interface{}
-		claim     string
-		expected  interface{}
-	}{
-		{nil, "data", nil},
-		{map[string]interface{}{"data": "foo"}, "data", "foo"},
-		{map[string]interface{}{"data": "foo"}, "data2", nil},
-		{map[string]interface{}{"data": "foo"}, "/data", "foo"},
-		{
-			map[string]interface{}{"data": map[string]interface{}{
-				"foo": "bar",
-			}}, "/data/foo", "bar",
-		},
-		{
-			map[string]interface{}{"data": map[string]interface{}{
-				"foo": "bar",
-			}}, "/data/foo2", nil,
-		},
+	data := `
+{
+  "a": 42,
+  "b": "bar",
+  "c": {
+    "d": 95,
+    "e": [
+      "dog",
+  	  "cat",
+  	  "bird"
+    ],
+	"f": {
+	  "g": "zebra"
+	}
+  }
+}
+`
+	var claims map[string]interface{}
+	if err := json.Unmarshal([]byte(data), &claims); err != nil {
+		t.Fatal(err)
+	}
 
-		{map[string]interface{}{"data": "foo"}, `\`, nil},
+	tests := []struct {
+		claim string
+		value interface{}
+	}{
+		{"a", float64(42)},
+		{"/a", float64(42)},
+		{"b", "bar"},
+		{"/c/d", float64(95)},
+		{"/c/e/1", "cat"},
+		{"/c/f/g", "zebra"},
+		{"nope", nil},
+		{"/c/f/h", nil},
+		{"", nil},
+		{"\\", nil},
 	}
 
 	for _, test := range tests {
-		actual := getClaim(test.allClaims, test.claim)
-		if diff := deep.Equal(actual, test.expected); diff != nil {
-			t.Fatalf("invalid results for claim '%s': %v", test.claim, diff)
+		v := getClaim(claims, test.claim)
+
+		if diff := deep.Equal(v, test.value); diff != nil {
+			t.Fatal(diff)
 		}
 	}
 }

--- a/path_login.go
+++ b/path_login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
@@ -40,13 +41,19 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 }
 
 func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	token := d.Get("jwt").(string)
-	if len(token) == 0 {
-		return logical.ErrorResponse("missing token"), nil
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return logical.ErrorResponse("could not load configuration"), nil
 	}
 
 	roleName := d.Get("role").(string)
-	if len(roleName) == 0 {
+	if roleName == "" {
+		roleName = config.DefaultRole
+	}
+	if roleName == "" {
 		return logical.ErrorResponse("missing role"), nil
 	}
 
@@ -55,19 +62,16 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse("role could not be found"), nil
+		return logical.ErrorResponse("role '%s' could not be found", roleName), nil
+	}
+
+	token := d.Get("jwt").(string)
+	if len(token) == 0 {
+		return logical.ErrorResponse("missing token"), nil
 	}
 
 	if req.Connection != nil && !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, role.BoundCIDRs) {
 		return logical.ErrorResponse("request originated from invalid CIDR"), nil
-	}
-
-	config, err := b.config(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return logical.ErrorResponse("could not load configuration"), nil
 	}
 
 	// Here is where things diverge. If it is using OIDC Discovery, validate
@@ -130,101 +134,29 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		}
 
 	case config.OIDCDiscoveryURL != "":
-		provider, err := b.getProvider(ctx, config)
+		allClaims, err = b.verifyToken(ctx, config, role, token)
 		if err != nil {
-			return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
-		}
-
-		verifier := provider.Verifier(&oidc.Config{
-			SkipClientIDCheck:    true,
-			SupportedSigningAlgs: config.JWTSupportedAlgs,
-		})
-
-		idToken, err := verifier.Verify(ctx, token)
-		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error validating signature: {{err}}", err).Error()), nil
-		}
-
-		if err := idToken.Claims(&allClaims); err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err).Error()), nil
-		}
-
-		if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
-			return logical.ErrorResponse("sub claim does not match bound subject"), nil
-		}
-		if len(role.BoundAudiences) != 0 {
-			var found bool
-			for _, v := range role.BoundAudiences {
-				if strutil.StrListContains(idToken.Audience, v) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return logical.ErrorResponse("aud claim does not match any bound audience"), nil
-			}
+			return logical.ErrorResponse(err.Error()), nil
 		}
 
 	default:
 		return nil, errors.New("unhandled case during login")
 	}
 
-	userClaimRaw, ok := allClaims[role.UserClaim]
-	if !ok {
-		return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.UserClaim)), nil
-	}
-	userName, ok := userClaimRaw.(string)
-	if !ok {
-		return logical.ErrorResponse(fmt.Sprintf("%q claim could not be converted to string", role.UserClaim)), nil
-	}
-
-	var groupAliases []*logical.Alias
-	if role.GroupsClaim != "" {
-		groupsClaimRaw := getClaim(allClaims, role.GroupsClaim)
-
-		if groupsClaimRaw == nil {
-			return logical.ErrorResponse("%q claim not found in token", role.GroupsClaim), nil
-		}
-		groups, ok := groupsClaimRaw.([]interface{})
-		if !ok {
-			return logical.ErrorResponse("%q claim could not be converted to string list", role.GroupsClaim), nil
-		}
-		for _, groupRaw := range groups {
-			group, ok := groupRaw.(string)
-			if !ok {
-				return logical.ErrorResponse("value %v in groups claim could not be parsed as string", groupRaw), nil
-			}
-			if group == "" {
-				continue
-			}
-			groupAliases = append(groupAliases, &logical.Alias{
-				Name: group,
-			})
-		}
-	}
-
-	// extract metadata for alias
-	metadata, err := extractMetadata(allClaims, role.ClaimMappings)
+	alias, groupAliases, err := b.createIdentity(allClaims, role)
 	if err != nil {
-		return nil, err
+		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	alias := &logical.Alias{
-		Name:     userName,
-		Metadata: metadata,
-	}
-
-	// include role in token metadata
-	tokenMetadata := make(map[string]string)
-	for k, v := range metadata {
+	tokenMetadata := map[string]string{"role": roleName}
+	for k, v := range alias.Metadata {
 		tokenMetadata[k] = v
 	}
-	tokenMetadata["role"] = roleName
 
 	resp := &logical.Response{
 		Auth: &logical.Auth{
 			Policies:     role.Policies,
-			DisplayName:  userName,
+			DisplayName:  alias.Name,
 			Period:       role.Period,
 			NumUses:      role.NumUses,
 			Alias:        alias,
@@ -265,6 +197,120 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	resp.Auth.MaxTTL = role.MaxTTL
 	resp.Auth.Period = role.Period
 	return resp, nil
+}
+
+func (b *jwtAuthBackend) verifyToken(ctx context.Context, config *jwtConfig, role *jwtRole, rawToken string) (map[string]interface{}, error) {
+	allClaims := make(map[string]interface{})
+
+	provider, err := b.getProvider(ctx, config)
+	if err != nil {
+		return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
+	}
+
+	var oidcConfig *oidc.Config
+	if role.RoleType == "oidc" {
+		oidcConfig = &oidc.Config{
+			ClientID: config.OIDCClientID,
+		}
+	} else {
+		oidcConfig = &oidc.Config{
+			SkipClientIDCheck:    true,
+			SupportedSigningAlgs: config.JWTSupportedAlgs,
+		}
+	}
+	verifier := provider.Verifier(oidcConfig)
+
+	idToken, err := verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, errwrap.Wrapf("error validating signature: {{err}}", err)
+	}
+
+	if err := idToken.Claims(&allClaims); err != nil {
+		return nil, errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err)
+	}
+
+	if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
+		return nil, errors.New("sub claim does not match bound subject")
+	}
+	if len(role.BoundAudiences) > 0 {
+		var found bool
+		for _, v := range role.BoundAudiences {
+			if strutil.StrListContains(idToken.Audience, v) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.New("aud claim does not match any bound audience")
+		}
+	}
+
+	if len(role.BoundClaims) > 0 {
+		for claim, expValue := range role.BoundClaims {
+			actValue := getClaim(allClaims, claim)
+			if actValue == nil {
+				return nil, fmt.Errorf("claim is missing: %s", claim)
+			}
+
+			if !reflect.DeepEqual(expValue, actValue) {
+				return nil, fmt.Errorf("claim '%s' does not match associated bound claim", claim)
+			}
+		}
+	}
+
+	return allClaims, nil
+}
+
+// createIdentity creates an alias and set of groups aliass based on the role
+// definition and received claims.
+func (b *jwtAuthBackend) createIdentity(allClaims map[string]interface{}, role *jwtRole) (*logical.Alias, []*logical.Alias, error) {
+	userClaimRaw, ok := allClaims[role.UserClaim]
+	if !ok {
+		return nil, nil, fmt.Errorf("claim %q not found in token", role.UserClaim)
+	}
+	userName, ok := userClaimRaw.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("claim %q could not be converted to string", role.UserClaim)
+	}
+
+	metadata, err := extractMetadata(allClaims, role.ClaimMappings)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	alias := &logical.Alias{
+		Name:     userName,
+		Metadata: metadata,
+	}
+
+	var groupAliases []*logical.Alias
+
+	if role.GroupsClaim != "" {
+		groupsClaimRaw := getClaim(allClaims, role.GroupsClaim)
+
+		if groupsClaimRaw == nil {
+			return nil, nil, fmt.Errorf("%q claim not found in token", role.GroupsClaim)
+		}
+		groups, ok := groupsClaimRaw.([]interface{})
+
+		if !ok {
+			return nil, nil, fmt.Errorf("%q claim could not be converted to string list", role.GroupsClaim)
+		}
+		for _, groupRaw := range groups {
+			group, ok := groupRaw.(string)
+			if !ok {
+				return nil, nil, fmt.Errorf("value %v in groups claim could not be parsed as string", groupRaw)
+			}
+			if group == "" {
+				continue
+			}
+			groupAliases = append(groupAliases, &logical.Alias{
+				Name: group,
+			})
+		}
+	}
+
+	return alias, groupAliases, nil
 }
 
 const (

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -134,7 +134,6 @@ func getTestOIDC(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	//t.Log(out.AccessToken)
 	return out.AccessToken
 }
 
@@ -631,7 +630,7 @@ func TestLogin_JWT(t *testing.T) {
 		if resp == nil || !resp.IsError() {
 			t.Fatal("expected error")
 		}
-		if resp.Error().Error() != "role could not be found" {
+		if resp.Error().Error() != "role 'plugin-test-bad' could not be found" {
 			t.Fatalf("unexpected error: %s", resp.Error())
 		}
 	}

--- a/path_ui.go
+++ b/path_ui.go
@@ -1,0 +1,37 @@
+// A throwaway file for super simple testing via a UI
+package jwtauth
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathUI(b *jwtAuthBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: `ui$`,
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation: b.pathUI,
+		},
+	}
+}
+
+func (b *jwtAuthBackend) pathUI(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	data, err := ioutil.ReadFile("test_ui.html")
+	if err != nil {
+		panic(err)
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPStatusCode:  200,
+			logical.HTTPRawBody:     string(data),
+			logical.HTTPContentType: "text/html",
+		},
+	}
+
+	return resp, nil
+}

--- a/scripts/local_dev.sh
+++ b/scripts/local_dev.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+
+MNT_PATH="jwt"
+PLUGIN_NAME="vault-plugin-auth-jwt"
+#
+# Helper script for local development. Automatically builds and registers the
+# plugin. Requires `vault` is installed and available on $PATH.
+#
+
+# Get the right dir
+DIR="$(cd "$(dirname "$(readlink "$0")")" && pwd)"
+
+echo "==> Starting dev"
+
+echo "--> Scratch dir"
+echo "    Creating"
+SCRATCH="$DIR/tmp"
+mkdir -p "$SCRATCH/plugins"
+
+echo "--> Vault server"
+echo "    Writing config"
+tee "$SCRATCH/vault.hcl" > /dev/null <<EOF
+plugin_directory = "$SCRATCH/plugins"
+EOF
+
+echo "    Envvars"
+export VAULT_DEV_ROOT_TOKEN_ID="root"
+export VAULT_ADDR="http://127.0.0.1:8200"
+
+echo "    Starting"
+vault server \
+  -dev \
+  -log-level="debug" \
+  -config="$SCRATCH/vault.hcl" \
+  -dev-ha -dev-transactional -dev-root-token-id=root \
+  &
+sleep 2
+VAULT_PID=$!
+
+function cleanup {
+  echo ""
+  echo "==> Cleaning up"
+  kill -INT "$VAULT_PID"
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+echo "    Authing"
+vault auth root &>/dev/null
+
+echo "--> Building"
+go build -o "$SCRATCH/plugins/$PLUGIN_NAME" "./cmd/$PLUGIN_NAME" 
+SHASUM=$(shasum -a 256 "$SCRATCH/plugins/$PLUGIN_NAME" | cut -d " " -f1)
+
+echo "    Registering plugin"
+vault write sys/plugins/catalog/$PLUGIN_NAME \
+  sha_256="$SHASUM" \
+  command="$PLUGIN_NAME"
+
+echo "    Mounting plugin"
+vault auth enable -path=$MNT_PATH -plugin-name=$PLUGIN_NAME plugin
+
+if [ -e scripts/custom.sh ]
+then
+  . scripts/custom.sh
+fi
+
+echo "==> Ready!"
+wait $!
+

--- a/test_ui.html
+++ b/test_ui.html
@@ -1,0 +1,37 @@
+<!-- A throwaway file for super simple testing via a UI -->
+<html>
+<body>
+Role:<br>
+<input id="role" type="text" value="test"/><br>
+<button id="login">Login</button>
+
+<script>
+document.getElementById("login").addEventListener("click", doLogin);
+
+function doLogin() {
+	role = document.getElementById("role").value;
+
+	fetch(`${window.location.origin}/v1/auth/jwt/oidc/auth_url`, {
+		method: "POST",
+		body: JSON.stringify({
+			role: role,
+			redirect_uri: `${window.location.origin}/v1/auth/jwt/oidc/callback`
+		})
+	}).then(function(response) {
+		return response.json();
+	}).then(function(myJSON) {
+		oidcAuth(myJSON.data.auth_url);
+	});
+}
+
+function oidcAuth(url) {
+	console.log(url)
+	url = url.replace("vaultserver", window.location.origin);
+	console.log(url)
+	location.replace(url);
+}
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR builds on the other two to complete the auth flow via the callback. A fair amount of the diff is with moving code from the original login function into standalone functions to be shared by the JWT and OIDC paths. The initial version of the code had a single login function regardless of path, but it was a confusing `if`/`switch` mess of shared & unique code.

Tests are forthcoming.