### PR TITLE
Log received OIDC claims in debug mode

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -231,6 +231,8 @@ func (b *jwtAuthBackend) verifyOIDCToken(ctx context.Context, config *jwtConfig,
 		return nil, errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err)
 	}
 
+	b.Logger().Debug("oidc auth", "ID token claims", allClaims)
+
 	if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
 		return nil, errors.New("sub claim does not match bound subject")
 	}

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -138,6 +138,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 	// endpoint will not invalidate the authorization flow.
 	if userinfo, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token)); err == nil {
 		_ = userinfo.Claims(&allClaims)
+		b.Logger().Debug("oidc auth", "userinfo claims", userinfo)
 	} else {
 		logFunc := b.Logger().Warn
 		if strings.Contains(err.Error(), "user info endpoint is not supported") {


### PR DESCRIPTION
Setting up OIDC is difficult if the user isn't sure what the claims data from the provider looks like. This change would log received claims data in Debug mode.

Sample output:

```
2019-03-12T16:23:54.282-0700 [DEBUG] auth.jwt.auth_jwt_aae171ba.jwt.vault-plugin-auth-jwt: oidc auth: ID token claims="map[aud:571359c6b83f474608769feba3777b11a308b17e5de5c6a10190 auth_time:1.552423617e+09 exp:1.552433154e+09 iat:1.552433034e+09 iss:https://gitlab.com nonce:3b69477945b82bca3d94e10a8809 sub:1883899 sub_legacy:855ee8f03ac1fb63dd71dfbea8588ebba2798e830d7]" timestamp=2019-03-12T16:23:54.282-0700
2019-03-12T16:23:54.404-0700 [DEBUG] auth.jwt.auth_jwt_aae171ba.jwt.vault-plugin-auth-jwt: oidc auth: userinfo claims="map[email:jim@example.com email_verified:true profile:https://gitlab.com/somename sub:188xxxx]" timestamp=2019-03-12T16:23:54.404-0700
```