### PR TITLE
Improve claims verification

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -1,8 +1,11 @@
 package jwtauth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/vault/helper/strutil"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/pointerstructure"
@@ -62,4 +65,41 @@ func extractMetadata(logger log.Logger, allClaims map[string]interface{}, claimM
 		}
 	}
 	return metadata, nil
+}
+
+// validateAudience checks whether any of the audiences in audClaim match those
+// in boundAudiences. If strict is true and there are no bound audiences, then the
+// presence of any audience in the received claim is considered an error.
+func validateAudience(boundAudiences, audClaim []string, strict bool) error {
+	if strict && len(boundAudiences) == 0 && len(audClaim) > 0 {
+		return errors.New("audience claim found in JWT but no audiences bound to the role")
+	}
+
+	if len(boundAudiences) > 0 {
+		for _, v := range boundAudiences {
+			if strutil.StrListContains(audClaim, v) {
+				return nil
+			}
+		}
+		return errors.New("aud claim does not match any bound audience")
+	}
+
+	return nil
+}
+
+// validateBoundClaims checks that all of the claim:value requirements in boundClaims are
+// met in allClaims.
+func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]interface{}) error {
+	for claim, expValue := range boundClaims {
+		actValue := getClaim(logger, allClaims, claim)
+		if actValue == nil {
+			return fmt.Errorf("claim %q is missing", claim)
+		}
+
+		if expValue != actValue {
+			return fmt.Errorf("claim %q does not match associated bound claim", claim)
+		}
+	}
+
+	return nil
 }

--- a/scripts/local_dev.sh
+++ b/scripts/local_dev.sh
@@ -49,7 +49,7 @@ function cleanup {
 trap cleanup EXIT
 
 echo "    Authing"
-vault auth root &>/dev/null
+vault login root &>/dev/null
 
 echo "--> Building"
 go build -o "$SCRATCH/plugins/$PLUGIN_NAME" "./cmd/$PLUGIN_NAME" 


### PR DESCRIPTION
- verify bound_claims in all paths
- verify bound_claims against /userinfo data
- verify bound_audiences in all paths
- revise bound_audiences check when using static keys to conform to our docs
- more tests

Fixes #30