### PR TITLE
explicitly close the listener

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -80,6 +80,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if err != nil {
 		return nil, err
 	}
+	defer listener.Close()
 
 	// Open the default browser to the callback URL.
 	fmt.Fprintf(os.Stderr, "Complete the login via your OIDC provider. Launching browser to:\n\n    %s\n\n\n", authURL)


### PR DESCRIPTION
The lifecycle of this listener is relatively short and it should be cleanup by the end of the CLI call as the program exits, but it wouldn't hurt to be explicitly calling `listener.Close()` when we're done serving.