### PR TITLE
Add functionality to check against a list of claims

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -1,6 +1,7 @@
 package jwtauth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -107,11 +108,22 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 			return fmt.Errorf("bound claim is not a string or list: %v", expValue)
 		}
 
+		var actVals []string
+		actData := []byte(actValue.(string))
+
+		err := json.Unmarshal(actData, &actVals)
+		if err != nil {
+			actVals = []string{actValue.(string)}
+		}
+
+
 		found := false
 		for _, v := range expVals {
-			if actValue == v {
-				found = true
-				break
+			for _, av := range actVals {
+				if av == v {
+					found = true
+					break
+				}
 			}
 		}
 

--- a/claims.go
+++ b/claims.go
@@ -1,7 +1,6 @@
 package jwtauth
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -97,7 +96,16 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 			return fmt.Errorf("claim %q is missing", claim)
 		}
 
-		var expVals []interface{}
+		var actVals, expVals []interface{}
+
+		switch v := actValue.(type) {
+		case []interface{}:
+			actVals = v
+		case string:
+			actVals = []interface{}{v}
+		default:
+			return fmt.Errorf("received claim is not a string or list: %v", actValue)
+		}
 
 		switch v := expValue.(type) {
 		case []interface{}:
@@ -107,15 +115,6 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 		default:
 			return fmt.Errorf("bound claim is not a string or list: %v", expValue)
 		}
-
-		var actVals []string
-		actData := []byte(actValue.(string))
-
-		err := json.Unmarshal(actData, &actVals)
-		if err != nil {
-			actVals = []string{actValue.(string)}
-		}
-
 
 		found := false
 		for _, v := range expVals {

--- a/claims.go
+++ b/claims.go
@@ -117,11 +117,13 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 		}
 
 		found := false
+
+	scan:
 		for _, v := range expVals {
 			for _, av := range actVals {
 				if av == v {
 					found = true
-					break
+					break scan
 				}
 			}
 		}

--- a/claims_test.go
+++ b/claims_test.go
@@ -198,6 +198,26 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name: "valid - match within list",
+			boundClaims: map[string]interface{}{
+				"foo": "a",
+			},
+			allClaims: map[string]interface{}{
+				"foo": `["a", "b"]`,
+			},
+			errExpected: false,
+		},
+		{
+			name: "invalid - no match within list",
+			boundClaims: map[string]interface{}{
+				"foo": "c",
+			},
+			allClaims: map[string]interface{}{
+				"foo": `["a", "b"]`,
+			},
+			errExpected: true,
+		},
+		{
 			name: "valid - extra data",
 			boundClaims: map[string]interface{}{
 				"foo": "a",

--- a/claims_test.go
+++ b/claims_test.go
@@ -198,12 +198,32 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name: "valid - non-string claim",
+			boundClaims: map[string]interface{}{
+				"foo": []interface{}{42},
+			},
+			allClaims: map[string]interface{}{
+				"foo": []interface{}{42},
+			},
+			errExpected: false,
+		},
+		{
 			name: "valid - match within list",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 			},
 			allClaims: map[string]interface{}{
-				"foo": `["a", "b"]`,
+				"foo": []interface{}{"a", "b"},
+			},
+			errExpected: false,
+		},
+		{
+			name: "valid - match list against list",
+			boundClaims: map[string]interface{}{
+				"foo": []interface{}{"a", "b", "c"},
+			},
+			allClaims: map[string]interface{}{
+				"foo": []interface{}{"c", "d"},
 			},
 			errExpected: false,
 		},
@@ -213,7 +233,17 @@ func TestValidateBoundClaims(t *testing.T) {
 				"foo": "c",
 			},
 			allClaims: map[string]interface{}{
-				"foo": `["a", "b"]`,
+				"foo": []interface{}{"a", "b"},
+			},
+			errExpected: true,
+		},
+		{
+			name: "invalid - no match list against list",
+			boundClaims: map[string]interface{}{
+				"foo": []interface{}{"a", "b", "c"},
+			},
+			allClaims: map[string]interface{}{
+				"foo": []interface{}{"d", "e"},
 			},
 			errExpected: true,
 		},
@@ -326,6 +356,16 @@ func TestValidateBoundClaims(t *testing.T) {
 			},
 			allClaims: map[string]interface{}{
 				"email": "d",
+			},
+			errExpected: true,
+		},
+		{
+			name: "invalid received claim expected value",
+			boundClaims: map[string]interface{}{
+				"email": "d",
+			},
+			allClaims: map[string]interface{}{
+				"email": 42,
 			},
 			errExpected: true,
 		},


### PR DESCRIPTION
If a list of claims is provided, unmarshal it and then search within that for the bound claim.

The intention is to allow me to pass a claim like:
```vault_role: ["admin", "superadmin"]```

This will allow me to log in as either `admin` or `superadmin` as I choose.

Useful for testing roles that other users have, or to allow people who sit across two teams to perform functions in both without adding additional roles.