### PR TITLE
Restore client_id check

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -255,7 +255,12 @@ func (b *jwtAuthBackend) verifyOIDCToken(ctx context.Context, config *jwtConfig,
 
 	oidcConfig := &oidc.Config{
 		SupportedSigningAlgs: config.JWTSupportedAlgs,
-		SkipClientIDCheck:    true,
+	}
+
+	if role.RoleType == "oidc" {
+		oidcConfig.ClientID = config.OIDCClientID
+	} else {
+		oidcConfig.SkipClientIDCheck = true
 	}
 
 	verifier := provider.Verifier(oidcConfig)

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -991,12 +991,18 @@ func TestLogin_JWKS_Concurrent(t *testing.T) {
 		Audience:  jwt.Audience{"https://vault.plugin.auth.jwt.test"},
 	}
 
+	type orgs struct {
+		Primary string `json:"primary"`
+	}
+
 	privateCl := struct {
 		User   string   `json:"https://vault/user"`
 		Groups []string `json:"https://vault/groups"`
+		Org    orgs     `json:"org"`
 	}{
 		"jeff",
 		[]string{"foo", "bar"},
+		orgs{"engineering"},
 	}
 
 	jwtData, _ := getTestJWT(t, ecdsaPrivKey, cl, privateCl)


### PR DESCRIPTION
This check was incorrectly removed for OIDC roles in https://github.com/hashicorp/vault-plugin-auth-jwt/pull/38.

The PR also includes a test for this case and some general test cleanup.