### PR TITLE
Add common token fields to OIDC login response

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -199,25 +199,29 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		tokenMetadata[k] = v
 	}
 
-	resp := &logical.Response{
-		Auth: &logical.Auth{
-			Policies:     role.Policies,
-			DisplayName:  alias.Name,
-			Period:       role.Period,
-			NumUses:      role.NumUses,
-			Alias:        alias,
-			GroupAliases: groupAliases,
-			InternalData: map[string]interface{}{
-				"role": roleName,
-			},
-			Metadata: tokenMetadata,
-			LeaseOptions: logical.LeaseOptions{
-				Renewable: true,
-				TTL:       role.TTL,
-				MaxTTL:    role.MaxTTL,
-			},
-			BoundCIDRs: role.BoundCIDRs,
+	auth := &logical.Auth{
+		Policies:     role.Policies,
+		DisplayName:  alias.Name,
+		Period:       role.Period,
+		NumUses:      role.NumUses,
+		Alias:        alias,
+		GroupAliases: groupAliases,
+		InternalData: map[string]interface{}{
+			"role": roleName,
 		},
+		Metadata: tokenMetadata,
+		LeaseOptions: logical.LeaseOptions{
+			Renewable: true,
+			TTL:       role.TTL,
+			MaxTTL:    role.MaxTTL,
+		},
+		BoundCIDRs: role.BoundCIDRs,
+	}
+
+	role.PopulateTokenAuth(auth)
+
+	resp := &logical.Response{
+		Auth: auth,
 	}
 
 	return resp, nil

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -290,6 +290,7 @@ func TestOIDC_Callback(t *testing.T) {
 					"color": "green",
 					"size":  "medium",
 				},
+				NumUses: 10,
 			}
 			if useBoundCIDRs {
 				sock, err := sockaddr.NewSockAddr("127.0.0.42")
@@ -896,9 +897,10 @@ func getBackendAndServer(t *testing.T, boundCIDRs bool) (logical.Backend, logica
 			"COLOR":        "color",
 			"/nested/Size": "size",
 		},
-		"groups_claim": "/nested/Groups",
-		"ttl":          "3m",
-		"max_ttl":      "5m",
+		"groups_claim":   "/nested/Groups",
+		"token_ttl":      "3m",
+		"token_num_uses": 10,
+		"max_ttl":        "5m",
 		"bound_claims": map[string]interface{}{
 			"password":            "foo",
 			"sk":                  "42",


### PR DESCRIPTION
This PR also reduces the chance of "too many open files" errors during
tests by closing httptest servers.

Fixes #66