### PR TITLE
Add support for boolean values in bound claims 

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -101,19 +101,19 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 		switch v := actValue.(type) {
 		case []interface{}:
 			actVals = v
-		case string:
+		case string, bool:
 			actVals = []interface{}{v}
 		default:
-			return fmt.Errorf("received claim is not a string or list: %v", actValue)
+			return fmt.Errorf("received claim is not a string, boolean or list: %v", actValue)
 		}
 
 		switch v := expValue.(type) {
 		case []interface{}:
 			expVals = v
-		case string:
+		case string, bool:
 			expVals = []interface{}{v}
 		default:
-			return fmt.Errorf("bound claim is not a string or list: %v", expValue)
+			return fmt.Errorf("bound claim is not a string, boolean or list: %v", expValue)
 		}
 
 		found := false

--- a/claims_test.go
+++ b/claims_test.go
@@ -208,6 +208,16 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name: "valid - boolean claim",
+			boundClaims: map[string]interface{}{
+				"email_verified": []interface{}{false},
+			},
+			allClaims: map[string]interface{}{
+				"email_verified": []interface{}{false},
+			},
+			errExpected: false,
+		},
+		{
 			name: "valid - match within list",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
@@ -359,6 +369,17 @@ func TestValidateBoundClaims(t *testing.T) {
 			},
 			errExpected: true,
 		},
+		{
+			name: "invalid bound claim expected boolean value",
+			boundClaims: map[string]interface{}{
+				"email_verified": true,
+			},
+			allClaims: map[string]interface{}{
+				"email_verified": "true",
+			},
+			errExpected: true,
+		},
+
 		{
 			name: "invalid received claim expected value",
 			boundClaims: map[string]interface{}{


### PR DESCRIPTION
The current implementation only supports strings and lists when cross-checking claim bounds. This change will allow boolean k-v items to be verified.

Standard claims can be of boolean type as per: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims





