### PR TITLE
more customisation for callback URL

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -20,7 +20,6 @@ const defaultMount = "oidc"
 const defaultPort = "8250"
 const defaultCallbackHost = "localhost"
 const defaultCallbackMethod = "http"
-const defaultCallbackPort = "8250"
 
 var errorRegex = regexp.MustCompile(`(?s)Errors:.*\* *(.*)`)
 
@@ -59,14 +58,14 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		callbackMethod = defaultCallbackMethod
 	}
 
-	callbackport, ok := m["callbackport"]
+	callbackPort, ok := m["callbackport"]
 	if !ok {
-		callbackport = defaultCallbackPort
+		callbackPort = port
 	}
 
 	role := m["role"]
 
-	authURL, err := fetchAuthURL(c, role, mount, callbackport, callbackMethod, callbackHost)
+	authURL, err := fetchAuthURL(c, role, mount, callbackPort, callbackMethod, callbackHost)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +249,7 @@ Configuration:
 	  Optional callback host adddress to use in OIDC redirect_uri (default: localhost).
 
   callbackport=<string>
-      Optional port to to use in OIDC redirect_uri (default: 8250).
+      Optional port to to use in OIDC redirect_uri (default: the value set for port).
 `
 
 	return strings.TrimSpace(help)

--- a/cli.go
+++ b/cli.go
@@ -19,6 +19,8 @@ import (
 const defaultMount = "oidc"
 const defaultPort = "8250"
 const defaultCallbackHost = "localhost"
+const defaultCallbackMethod = "http"
+const defaultCallbackPort = "8250"
 
 var errorRegex = regexp.MustCompile(`(?s)Errors:.*\* *(.*)`)
 
@@ -52,9 +54,19 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		callbackHost = defaultCallbackHost
 	}
 
+	callbackMethod, ok := m["callbackmethod"]
+	if !ok {
+		callbackMethod = defaultCallbackMethod
+	}
+
+	callbackport, ok := m["callbackport"]
+	if !ok {
+		callbackport = defaultCallbackPort
+	}
+
 	role := m["role"]
 
-	authURL, err := fetchAuthURL(c, role, mount, port, callbackHost)
+	authURL, err := fetchAuthURL(c, role, mount, callbackport, callbackMethod, callbackHost)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +124,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	}
 }
 
-func fetchAuthURL(c *api.Client, role, mount, port string, callbackHost string) (string, error) {
+func fetchAuthURL(c *api.Client, role, mount, callbackport string, callbackMethod string, callbackHost string) (string, error) {
 	var authURL string
 
 	data := map[string]interface{}{
 		"role":         role,
-		"redirect_uri": fmt.Sprintf("http://%s:%s/oidc/callback", callbackHost, port),
+		"redirect_uri": fmt.Sprintf("%s://%s:%s/oidc/callback", callbackMethod, callbackHost, callbackport),
 	}
 
 	secret, err := c.Logical().Write(fmt.Sprintf("auth/%s/oidc/auth_url", mount), data)
@@ -229,7 +241,16 @@ Configuration:
       Vault role of type "OIDC" to use for authentication.
 
   port=<string>
-      Optional localhost port to use for OIDC callback (default: 8250).
+	  Optional localhost port to use for OIDC callback (default: 8250).
+
+  callbackmethod=<string>
+	  Optional method to to use in OIDC redirect_uri (default: http).
+
+  callbackhost=<string>
+	  Optional callback host adddress to use in OIDC redirect_uri (default: localhost).
+
+  callbackport=<string>
+      Optional port to to use in OIDC redirect_uri (default: 8250).
 `
 
 	return strings.TrimSpace(help)


### PR DESCRIPTION
Solves https://github.com/hashicorp/vault-plugin-auth-jwt/issues/79

* allow for setting `http` or `https` method in `redirect_uri`
* allow for setting port in `redirect_uri`
* updated plugin help info 

