### PR TITLE
Add the ability to match bound claims using globs

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -116,10 +116,7 @@ func validateBoundClaims(logger log.Logger, boundClaimsType string, boundClaims,
 	scan:
 		for _, v := range expVals {
 			if useGlobs {
-				vs, ok := v.(string)
-				if !ok {
-					return fmt.Errorf("received claim is not a glob string: %v", v)
-				}
+				vs := v.(string)
 				for _, av := range actVals {
 					if avs, ok := av.(string); ok {
 						if glob.Glob(vs, avs) {

--- a/claims.go
+++ b/claims.go
@@ -91,10 +91,6 @@ func validateAudience(boundAudiences, audClaim []string, strict bool) error {
 // validateBoundClaims checks that all of the claim:value requirements in boundClaims are
 // met in allClaims.
 func validateBoundClaims(logger log.Logger, boundClaimsType string, boundClaims, allClaims map[string]interface{}) error {
-	if boundClaimsType != boundClaimsTypeString && boundClaimsType != boundClaimsTypeGlob {
-		return fmt.Errorf("claim type %s is not valid", boundClaimsType)
-	}
-
 	useGlobs := boundClaimsType == boundClaimsTypeGlob
 
 	for claim, expValue := range boundClaims {

--- a/claims.go
+++ b/claims.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/ryanuber/go-glob"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/pointerstructure"
@@ -89,7 +90,13 @@ func validateAudience(boundAudiences, audClaim []string, strict bool) error {
 
 // validateBoundClaims checks that all of the claim:value requirements in boundClaims are
 // met in allClaims.
-func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]interface{}) error {
+func validateBoundClaims(logger log.Logger, boundClaimsType string, boundClaims, allClaims map[string]interface{}) error {
+	if boundClaimsType != boundClaimsTypeString && boundClaimsType != boundClaimsTypeGlob {
+		return fmt.Errorf("claim type %s is not valid", boundClaimsType)
+	}
+
+	useGlobs := boundClaimsType == boundClaimsTypeGlob
+
 	for claim, expValue := range boundClaims {
 		actValue := getClaim(logger, allClaims, claim)
 		if actValue == nil {
@@ -112,10 +119,25 @@ func validateBoundClaims(logger log.Logger, boundClaims, allClaims map[string]in
 
 	scan:
 		for _, v := range expVals {
-			for _, av := range actVals {
-				if av == v {
-					found = true
-					break scan
+			if useGlobs {
+				vs, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("received claim is not a glob string: %v", v)
+				}
+				for _, av := range actVals {
+					if avs, ok := av.(string); ok {
+						if glob.Glob(vs, avs) {
+							found = true
+							break scan
+						}
+					}
+				}
+			} else {
+				for _, av := range actVals {
+					if av == v {
+						found = true
+						break scan
+					}
 				}
 			}
 		}

--- a/claims_test.go
+++ b/claims_test.go
@@ -467,6 +467,17 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:            "not matching glob in list",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": []interface{}{"4*d", "42*"},
+			},
+			allClaims: map[string]interface{}{
+				"email": "43x",
+			},
+			errExpected: true,
+		},
+		{
 			name:            "non matching integer glob",
 			boundClaimsType: "glob",
 			boundClaims: map[string]interface{}{

--- a/claims_test.go
+++ b/claims_test.go
@@ -181,13 +181,15 @@ func TestValidateAudience(t *testing.T) {
 
 func TestValidateBoundClaims(t *testing.T) {
 	tests := []struct {
-		name        string
-		boundClaims map[string]interface{}
-		allClaims   map[string]interface{}
-		errExpected bool
+		name            string
+		boundClaimsType string
+		boundClaims     map[string]interface{}
+		allClaims       map[string]interface{}
+		errExpected     bool
 	}{
 		{
-			name: "valid",
+			name:            "valid",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 				"bar": "b",
@@ -199,7 +201,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "valid - non-string claim",
+			name:            "valid - non-string claim",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": []interface{}{42},
 			},
@@ -209,7 +212,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "valid - boolean claim",
+			name:            "valid - boolean claim",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email_verified": []interface{}{false},
 			},
@@ -219,7 +223,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "valid - match within list",
+			name:            "valid - match within list",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 			},
@@ -229,7 +234,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "valid - match list against list",
+			name:            "valid - match list against list",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": []interface{}{"a", "b", "c"},
 			},
@@ -239,7 +245,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "invalid - no match within list",
+			name:            "invalid - no match within list",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "c",
 			},
@@ -249,7 +256,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "invalid - no match list against list",
+			name:            "invalid - no match list against list",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": []interface{}{"a", "b", "c"},
 			},
@@ -259,7 +267,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "valid - extra data",
+			name:            "valid - extra data",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 				"bar": "b",
@@ -272,7 +281,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "mismatched value",
+			name:            "mismatched value",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 				"bar": "b",
@@ -284,7 +294,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "missing claim",
+			name:            "missing claim",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo": "a",
 				"bar": "b",
@@ -295,7 +306,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "valid - JSONPointer",
+			name:            "valid - JSONPointer",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo":        "a",
 				"/bar/baz/1": "y",
@@ -309,7 +321,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "invalid - JSONPointer value mismatch",
+			name:            "invalid - JSONPointer value mismatch",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo":        "a",
 				"/bar/baz/1": "q",
@@ -323,7 +336,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "invalid - JSONPointer not found",
+			name:            "invalid - JSONPointer not found",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"foo":           "a",
 				"/bar/XXX/1243": "q",
@@ -337,7 +351,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "valid - match alternates",
+			name:            "valid - match alternates",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email": []interface{}{"a", "b", "c"},
 				"color": "green",
@@ -349,7 +364,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
-			name: "invalid - no match alternates",
+			name:            "invalid - no match alternates",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email": []interface{}{"a", "b", "c"},
 				"color": "green",
@@ -361,7 +377,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "invalid bound claim expected value",
+			name:            "invalid bound claim expected value",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email": 42,
 			},
@@ -371,7 +388,8 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "invalid bound claim expected boolean value",
+			name:            "invalid bound claim expected boolean value",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email_verified": true,
 			},
@@ -382,7 +400,8 @@ func TestValidateBoundClaims(t *testing.T) {
 		},
 
 		{
-			name: "invalid received claim expected value",
+			name:            "invalid received claim expected value",
+			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
 				"email": "d",
 			},
@@ -391,9 +410,97 @@ func TestValidateBoundClaims(t *testing.T) {
 			},
 			errExpected: true,
 		},
+
+		{
+			name:            "matching glob",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": "4*",
+			},
+			allClaims: map[string]interface{}{
+				"email": "42",
+			},
+			errExpected: false,
+		},
+		{
+			name:            "invalid string value",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": "4*",
+			},
+			allClaims: map[string]interface{}{
+				"email": 42,
+			},
+			errExpected: true,
+		},
+		{
+			name:            "not matching glob",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": "4*",
+			},
+			allClaims: map[string]interface{}{
+				"email": "d42",
+			},
+			errExpected: true,
+		},
+		{
+			name:            "not matching glob",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": "*2",
+			},
+			allClaims: map[string]interface{}{
+				"email": "42x",
+			},
+			errExpected: true,
+		},
+		{
+			name:            "matching glob in list",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": []interface{}{"4*d", "42*"},
+			},
+			allClaims: map[string]interface{}{
+				"email": "42x",
+			},
+			errExpected: false,
+		},
+		{
+			name:            "non matching integer glob",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": 42,
+			},
+			allClaims: map[string]interface{}{
+				"email": "42x",
+			},
+			errExpected: true,
+		},
+		{
+			name:            "valid complex glob",
+			boundClaimsType: "glob",
+			boundClaims: map[string]interface{}{
+				"email": `*@*.com`,
+			},
+			allClaims: map[string]interface{}{
+				"email": "test@example.com",
+			},
+			errExpected: false,
+		},
+		{
+			name: "non matching complex glob",
+			boundClaims: map[string]interface{}{
+				"email": `r*@*.com`,
+			},
+			allClaims: map[string]interface{}{
+				"email": "test@example.com",
+			},
+			errExpected: true,
+		},
 	}
 	for _, tt := range tests {
-		if err := validateBoundClaims(hclog.NewNullLogger(), tt.boundClaims, tt.allClaims); (err != nil) != tt.errExpected {
+		if err := validateBoundClaims(hclog.NewNullLogger(), tt.boundClaimsType, tt.boundClaims, tt.allClaims); (err != nil) != tt.errExpected {
 			t.Errorf("validateBoundClaims(%s) error = %v, wantErr %v", tt.name, err, tt.errExpected)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mitchellh/pointerstructure v0.0.0-20190430161007-f252a8fd71c8
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
+	github.com/ryanuber/go-glob v1.0.0
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 	gopkg.in/square/go-jose.v2 v2.3.1
 )

--- a/path_login.go
+++ b/path_login.go
@@ -213,7 +213,7 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return nil, errors.New("unhandled case during login")
 	}
 
-	if err := validateBoundClaims(b.Logger(), role.BoundClaims, allClaims); err != nil {
+	if err := validateBoundClaims(b.Logger(), role.BoundClaimsType, role.BoundClaims, allClaims); err != nil {
 		return logical.ErrorResponse("error validating claims: %s", err.Error()), nil
 	}
 

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -185,7 +185,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 	}
 
-	if err := validateBoundClaims(b.Logger(), role.BoundClaims, allClaims); err != nil {
+	if err := validateBoundClaims(b.Logger(), role.BoundClaimsType, role.BoundClaims, allClaims); err != nil {
 		return logical.ErrorResponse("error validating claims: %s", err.Error()), nil
 	}
 

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -673,6 +673,26 @@ func TestPath_Read(t *testing.T) {
 	// Run read test for "upgrade" case. The legacy role is not changed in storage, but
 	// reads will populate the `role_type` with "jwt".
 	readTest()
+
+	// Remove the 'bound_claims_type' parameter in stored role to simulate a legacy role
+	raw, err = storage.Get(context.Background(), rolePath)
+
+	if err := raw.DecodeJSON(&role); err != nil {
+		t.Fatal(err)
+	}
+	delete(role, "bound_claims_type")
+	entry, err = logical.StorageEntryJSON(rolePath, role)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = req.Storage.Put(context.Background(), entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run read test for "upgrade" case. The legacy role is not changed in storage, but
+	// reads will populate the `bound_claims_type` with "jwt".
+	readTest()
 }
 
 func TestPath_Delete(t *testing.T) {

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -691,7 +691,7 @@ func TestPath_Read(t *testing.T) {
 	}
 
 	// Run read test for "upgrade" case. The legacy role is not changed in storage, but
-	// reads will populate the `bound_claims_type` with "jwt".
+	// reads will populate the `bound_claims_type` with "string".
 	readTest()
 }
 

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -73,6 +73,7 @@ func TestPath_Create(t *testing.T) {
 		Period:              3 * time.Second,
 		BoundSubject:        "testsub",
 		BoundAudiences:      []string{"vault"},
+		BoundClaimsType:     "string",
 		UserClaim:           "user",
 		GroupsClaim:         "groups",
 		TTL:                 1 * time.Second,
@@ -419,10 +420,11 @@ func TestPath_OIDCCreate(t *testing.T) {
 			TokenMaxTTL:   5 * time.Second,
 			TokenNumUses:  12,
 		},
-		RoleType:       "oidc",
-		Policies:       []string{"test"},
-		Period:         3 * time.Second,
-		BoundAudiences: []string{"vault"},
+		RoleType:        "oidc",
+		Policies:        []string{"test"},
+		Period:          3 * time.Second,
+		BoundAudiences:  []string{"vault"},
+		BoundClaimsType: "string",
 		BoundClaims: map[string]interface{}{
 			"foo": json.Number("10"),
 			"bar": "baz",
@@ -582,6 +584,7 @@ func TestPath_Read(t *testing.T) {
 
 	expected := map[string]interface{}{
 		"role_type":               "jwt",
+		"bound_claims_type":       "string",
 		"bound_claims":            map[string]interface{}(nil),
 		"claim_mappings":          map[string]string(nil),
 		"bound_subject":           "testsub",

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -383,6 +383,104 @@ func TestPath_Create(t *testing.T) {
 	if actual.NotBeforeLeeway.Seconds() != -1 {
 		t.Fatalf("not_before_leeway - expected: -1, got: %v", actual.NotBeforeLeeway.Seconds())
 	}
+
+	// Test storing an invalid bound_claim_type
+	data = map[string]interface{}{
+		"role_type":         "jwt",
+		"user_claim":        "user",
+		"policies":          "test",
+		"clock_skew_leeway": "-1",
+		"expiration_leeway": "-1",
+		"not_before_leeway": "-1",
+		"bound_claims_type": "invalid",
+		"bound_claims": map[string]interface{}{
+			"foo": 10,
+			"bar": "baz",
+		},
+	}
+
+	req = &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/test10",
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && !resp.IsError() {
+		t.Fatalf("expected error")
+	}
+	if resp.Error().Error() != "invalid 'bound_claims_type': invalid" {
+		t.Fatalf("unexpected err: %v", resp)
+	}
+
+	// Test a role with an invalid glob in a claim
+	data = map[string]interface{}{
+		"role_type":         "jwt",
+		"user_claim":        "user",
+		"policies":          "test",
+		"clock_skew_leeway": "-1",
+		"expiration_leeway": "-1",
+		"not_before_leeway": "-1",
+		"bound_claims_type": "glob",
+		"bound_claims": map[string]interface{}{
+			"bar": "baz",
+			"foo": 25,
+		},
+	}
+
+	req = &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/test11",
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && !resp.IsError() {
+		t.Fatalf("expected error")
+	}
+	if resp.Error().Error() != "claim is not a string or list: 25" {
+		t.Fatalf("unexpected err: %v", resp)
+	}
+
+	// Test a role with an invalid glob in a claim array
+	data = map[string]interface{}{
+		"role_type":         "jwt",
+		"user_claim":        "user",
+		"policies":          "test",
+		"clock_skew_leeway": "-1",
+		"expiration_leeway": "-1",
+		"not_before_leeway": "-1",
+		"bound_claims_type": "glob",
+		"bound_claims": map[string]interface{}{
+			"foo": []interface{}{"baz", 10},
+		},
+	}
+
+	req = &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/test12",
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && !resp.IsError() {
+		t.Fatalf("expected error")
+	}
+	if resp.Error().Error() != "claim is not a string: 10" {
+		t.Fatalf("unexpected err: %v", resp)
+	}
 }
 
 func TestPath_OIDCCreate(t *testing.T) {


### PR DESCRIPTION
This merge request is intended to add the ability to match bound claims not only using an exact string matching, but also a mathcing based on regular expressions.
Added a new flag `bound_claims_are_regexps`; if it is set to true the vaule of each entry in the `bound_claims` map is expected to be a string (not an array of strings) that will be interpreted as a regular expresison. The syntax for the regular expressions is the golang syntax.

This would allow mathcing JWT whose claims, for example, contain randomly generated portions of text.

Solves issue https://github.com/hashicorp/vault-plugin-auth-jwt/issues/82