### PR TITLE
Add timeout to OIDC callback server listener

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 )
@@ -120,12 +121,14 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		}
 	}()
 
-	// Wait for either the callback to finish or SIGINT to be received
+	// Wait for either the callback to finish, SIGINT to be received or up to 2 minutes
 	select {
 	case s := <-doneCh:
 		return s.secret, s.err
 	case <-sigintCh:
 		return nil, errors.New("Interrupted")
+	case <-time.After(2 * time.Minute):
+		return nil, errors.New("Timed out waiting for response from provider")
 	}
 }
 


### PR DESCRIPTION
We've seen some users initiate a Vault login using the OIDC method via the Vault CLI (`vault login -method=oidc`) and become distracted mid login and not complete the OIDC flow in their browser. 

When they attempt later to log in from another terminal tab or window using `vault login -method=oidc`, they received the error `listen tcp :8250: bind: address already in use` because the callback server from the initial login call is still running in a terminal somewhere.

This pull request adds a 2 minute timeout to the callback server to avoid zombie callback servers sticking around on a user's machine potentially indefinitely. I picked 2 minutes mostly arbitrarily based on how long I thought it usually takes me to do a login to an OIDC provider (including both password entry and 2FA second factor entry), so I am happy to adjust that timeout if it is too long or too short in anyone's opinion.

I tested a local build of the Vault CLI with this change. On the first test, login worked as normal when I completed the OIDC flow. On a second run I did not complete the OIDC flow in my browser and after 2 minutes the process terminated with the following output:
```
> ./bin/vault login -method=oidc
Complete the login via your OIDC provider. Launching browser to:

    <URL omitted>

Error authenticating: Timed out waiting for response from provider
```