### PR TITLE
Add optional client_nonce for OIDC logins

### DIFF
--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -750,7 +750,7 @@ func TestOIDC_Callback(t *testing.T) {
 			// set mock provider's expected code
 			s.code = "abc"
 
-			// invoke the callback, which will in to try to exchange the code
+			// invoke the callback, which will try to exchange the code
 			// with the mock provider.
 			req = &logical.Request{
 				Operation: logical.ReadOperation,

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -685,6 +685,95 @@ func TestOIDC_Callback(t *testing.T) {
 			t.Fatalf("expected invalid client_id error, got : %v", *resp)
 		}
 	})
+
+	t.Run("client_nonce", func(t *testing.T) {
+		b, storage, s := getBackendAndServer(t, false)
+		defer s.server.Close()
+
+		// General behavior is that if a client_nonce is provided during the authURL phase
+		// it must be provided during the callback phase.
+		tests := map[string]struct {
+			authURLNonce  string
+			callbackNonce string
+			errExpected   bool
+		}{
+			"default, no nonces": {
+				errExpected: false,
+			},
+			"matching nonces": {
+				authURLNonce:  "abc123",
+				callbackNonce: "abc123",
+				errExpected:   false,
+			},
+			"mismatched nonces": {
+				authURLNonce:  "abc123",
+				callbackNonce: "abc123xyz",
+				errExpected:   true,
+			},
+			"missing nonce": {
+				authURLNonce: "abc123",
+				errExpected:  true,
+			},
+			"ignore unexpected callback nonce": {
+				callbackNonce: "abc123",
+				errExpected:   false,
+			},
+		}
+
+		for name, test := range tests {
+			// get auth_url
+			data := map[string]interface{}{
+				"role":         "test",
+				"redirect_uri": "https://example.com",
+				"client_nonce": test.authURLNonce,
+			}
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      "oidc/auth_url",
+				Storage:   storage,
+				Data:      data,
+			}
+
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v\n", err, resp)
+			}
+
+			authURL := resp.Data["auth_url"].(string)
+
+			state := getQueryParam(t, authURL, "state")
+			nonce := getQueryParam(t, authURL, "nonce")
+
+			// set provider claims that will be returned by the mock server
+			s.customClaims = sampleClaims(nonce)
+
+			// set mock provider's expected code
+			s.code = "abc"
+
+			// invoke the callback, which will in to try to exchange the code
+			// with the mock provider.
+			req = &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      "oidc/callback",
+				Storage:   storage,
+				Data: map[string]interface{}{
+					"state":        state,
+					"code":         "abc",
+					"client_nonce": test.callbackNonce,
+				},
+			}
+
+			resp, err = b.HandleRequest(context.Background(), req)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.errExpected != resp.IsError() {
+				t.Fatalf("%s: unexpected error response, expected: %v,  got: %v", name, test.errExpected, resp.Data)
+			}
+		}
+	})
 }
 
 // oidcProvider is local server the mocks the basis endpoints used by the


### PR DESCRIPTION
This optional nonce hardens the multi-step OIDC login process. If the
client provides a nonce at the start (auth_url) phase, it must provide
the same nonce as part of the callback.

The motivation for this is primarily CLI logins. The CLI listener is
necessarily unencrypted, and theoretically if an attacker stole the OAuth
authorization_code enroute to the CLI listener, it could post that to
Vault and gain access. The CLI leverages the new client_nonce support to
harden this flow. Only the CLI process (and Vault) will know the
client_nonce, so an attacker will be unable to complete the login even
if they manage to steal the authorization_code.