### PR TITLE
Add ability to store refresh token into a secrets plugin

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -337,18 +337,18 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 		storePath := role.RefreshStorePath
 		for {
-			/* replace claims in storePath of form {claim} with its value */
-			start := strings.Index(storePath, "{")
+			/* replace claims in storePath of form {{claim}} with its value */
+			start := strings.Index(storePath, "{{")
 			if start == -1 {
 				break
 			}
-			end := strings.Index(storePath, "}")
+			end := strings.Index(storePath, "}}")
 			if end < start {
 				return logical.ErrorResponse("mismatched brackets in refresh_store_path %s", role.RefreshStorePath), nil
 			}
-			claim := storePath[start+1:end]
+			claim := storePath[start+2:end]
 			if val, ok := allClaims[claim]; ok {
-				storePath = strings.ReplaceAll(storePath, "{" + claim + "}", val.(string))
+				storePath = strings.ReplaceAll(storePath, "{{" + claim + "}}", val.(string))
 			} else {
 				return logical.ErrorResponse("no claim %s found for refresh_store_path %s", claim, role.RefreshStorePath), nil
 			}

--- a/path_role.go
+++ b/path_role.go
@@ -144,6 +144,14 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 Not recommended in production since sensitive information may be present 
 in OIDC responses.`,
 			},
+			"refresh_store_path": {
+				Type:        framework.TypeString,
+				Description: `Vault path to store refresh token`,
+			},
+			"refresh_store_cred": {
+				Type:        framework.TypeString,
+				Description: `Vault credential (that is, token) to use when storing refresh token`,
+			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -202,6 +210,8 @@ type jwtRole struct {
 	OIDCScopes          []string               `json:"oidc_scopes"`
 	AllowedRedirectURIs []string               `json:"allowed_redirect_uris"`
 	VerboseOIDCLogging  bool                   `json:"verbose_oidc_logging"`
+	RefreshStorePath    string                 `json:"refresh_store_path"`
+	RefreshStoreCred    string                 `json:"refresh_store_cred"`
 
 	// Deprecated by TokenParams
 	Policies   []string                      `json:"policies"`
@@ -308,6 +318,8 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 		"allowed_redirect_uris": role.AllowedRedirectURIs,
 		"oidc_scopes":           role.OIDCScopes,
 		"verbose_oidc_logging":  role.VerboseOIDCLogging,
+		"refresh_store_path":    role.RefreshStorePath,
+		"refresh_store_cred":    role.RefreshStoreCred,
 	}
 
 	role.PopulateTokenData(d)
@@ -439,6 +451,13 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 
 	if verboseOIDCLoggingRaw, ok := data.GetOk("verbose_oidc_logging"); ok {
 		role.VerboseOIDCLogging = verboseOIDCLoggingRaw.(bool)
+	}
+
+	if refreshStorePath, ok := data.GetOk("refresh_store_path"); ok {
+		role.RefreshStorePath = refreshStorePath.(string)
+	}
+	if refreshStoreCred, ok := data.GetOk("refresh_store_cred"); ok {
+		role.RefreshStoreCred = refreshStoreCred.(string)
 	}
 
 	boundClaimsType := data.Get("bound_claims_type").(string)


### PR DESCRIPTION
# Overview
This PR adds configuration options to store a received refresh_token into the given path in vault.  It has been tested with the [Puppet Labs oauthapp vault plugin](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp) and the corresponding [pull request](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/pull/6) that accepts the refresh token.

These options make it possible for a user to authenticate with vault once and from then on be able to get access tokens from the OIDC provider via the secrets plugin.  This is needed by the High Energy Physics science community as they migrate their global computing from X.509 certificates to OIDC tokens.

# Design of Change
The role configuration option `refresh_store_path` can be set to specify a vault path to write into.  The path may contain any claim names from the id_token surrounded by double curly brackets (for example "{{email}}", which are replaced by the value of the claim.  The role configuration option `refresh_store_cred` should contain a vault token with sufficient privileges to write to the path, or the token set in the environment variable VAULT_TOKEN.

# Related Issues/Pull Requests
Addresses issue #101.

# Contributor Checklist
I will write the docs if this PR is otherwise deemed acceptable.

[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[  ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
