### PR TITLE
Moves auth_url error message for non-OIDC flow into ui constants

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -28,6 +28,7 @@ const (
 	errLoginFailed       = "Vault login failed."
 	errNoResponse        = "No response from provider."
 	errTokenVerification = "Token verification failed."
+	errNotOIDCFlow       = "OIDC login is not configured for this mount"
 
 	noCode = "no_code"
 )
@@ -344,7 +345,7 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if config.authType() != OIDCFlow {
-		return logical.ErrorResponse("OIDC login is not configured for this mount"), nil
+		return logical.ErrorResponse(errNotOIDCFlow), nil
 	}
 
 	roleName := d.Get("role").(string)


### PR DESCRIPTION
# Overview
Moves the `/auth_url` error message for non-OIDC flows into the constants section containing error messages used in the Vault UI.

# Design of Change
This change was primarily done in the Vault UI. See related PR below for full explanation.

# Related Issues/Pull Requests
- [PR #8952](https://github.com/hashicorp/vault/pull/8952)

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
