### PR TITLE
Add refresh_field option to put refresh token in metadata

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -122,6 +122,10 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 				Type:        framework.TypeKVPairs,
 				Description: `Mappings of claims (key) that will be copied to a metadata field (value)`,
 			},
+			"refresh_field": {
+				Type:        framework.TypeString,
+				Description: `Name of metadata field for refresh token`,
+			},
 			"user_claim": {
 				Type:        framework.TypeString,
 				Description: `The claim to use for the Identity entity alias name`,
@@ -197,6 +201,7 @@ type jwtRole struct {
 	BoundClaimsType     string                 `json:"bound_claims_type"`
 	BoundClaims         map[string]interface{} `json:"bound_claims"`
 	ClaimMappings       map[string]string      `json:"claim_mappings"`
+	RefreshField        string                 `json:"refresh_field"`
 	UserClaim           string                 `json:"user_claim"`
 	GroupsClaim         string                 `json:"groups_claim"`
 	OIDCScopes          []string               `json:"oidc_scopes"`
@@ -303,6 +308,7 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 		"bound_claims_type":     role.BoundClaimsType,
 		"bound_claims":          role.BoundClaims,
 		"claim_mappings":        role.ClaimMappings,
+		"refresh_field":         role.RefreshField,
 		"user_claim":            role.UserClaim,
 		"groups_claim":          role.GroupsClaim,
 		"allowed_redirect_uris": role.AllowedRedirectURIs,
@@ -487,6 +493,10 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		}
 
 		role.ClaimMappings = claimMappings
+	}
+
+	if refreshField, ok := data.GetOk("refresh_field"); ok {
+		role.RefreshField = refreshField.(string)
 	}
 
 	if userClaim, ok := data.GetOk("user_claim"); ok {


### PR DESCRIPTION
# Overview
This PR adds a configuration option refresh_field to return the refresh token in metadata under the name given by the option.

This options makes it possible for a user to authenticate with vault once and with some help from a client application store the token back into a vault secrets plugin like the [Puppet labs oauthapp](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp).  From then on access tokens can be read from the secrets plugin.  This is needed by the High Energy Physics science community including the thousands of members of the collaborations running experiments at the Large Hadron Colider.

# Design of Change

The new option simply puts the refresh token into the returned metadata in a similar way to the claims_mapping option.

# Related Issues/Pull Requests
This is another way of addressing issue #101 that is simpler than the rejected pull request #107.

# Contributor Checklist
I will write the docs if this PR is otherwise deemed acceptable.

[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
