### PR TITLE
Improve authorization error

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -168,9 +168,10 @@ func fetchAuthURL(c *api.Client, role, mount, callbackport string, callbackMetho
 		return "", "", err
 	}
 
+	redirectURI := fmt.Sprintf("%s://%s:%s/oidc/callback", callbackMethod, callbackHost, callbackport)
 	data := map[string]interface{}{
 		"role":         role,
-		"redirect_uri": fmt.Sprintf("%s://%s:%s/oidc/callback", callbackMethod, callbackHost, callbackport),
+		"redirect_uri": redirectURI,
 		"client_nonce": clientNonce,
 	}
 
@@ -184,7 +185,7 @@ func fetchAuthURL(c *api.Client, role, mount, callbackport string, callbackMetho
 	}
 
 	if authURL == "" {
-		return "", "", fmt.Errorf("Unable to authorize role %q. Check Vault logs for more information.", role)
+		return "", "", fmt.Errorf("Unable to authorize role %q with redirect_uri %q. Check Vault logs for more information.", role, redirectURI)
 	}
 
 	return authURL, clientNonce, nil


### PR DESCRIPTION
# Overview

When using a custom allowed_redirect_uris for specific roles
we don't show a relationship between the role and the
redirect_uri when an authorization error occurred,
frustrating the user thinking that the problem is in
the role and not in the allowed_redirect_uris flag.

This error is common occurred with the CLI when the administrator doesn't add an allowed localhost path.