### PR TITLE
Adds OIDC namespace_in_state option

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -94,7 +94,7 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 					},
 				},
 			},
-			"pass_namespace_in_state": {
+			"namespace_in_state": {
 				Type:        framework.TypeBool,
 				Description: "Pass namespace in the state parameter instead of as a separate query parameter. With this setting the allowed redirect URL in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it.",
 				Default:     false,
@@ -164,19 +164,19 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"oidc_discovery_url":      config.OIDCDiscoveryURL,
-			"oidc_discovery_ca_pem":   config.OIDCDiscoveryCAPEM,
-			"oidc_client_id":          config.OIDCClientID,
-			"oidc_response_mode":      config.OIDCResponseMode,
-			"oidc_response_types":     config.OIDCResponseTypes,
-			"default_role":            config.DefaultRole,
-			"jwt_validation_pubkeys":  config.JWTValidationPubKeys,
-			"jwt_supported_algs":      config.JWTSupportedAlgs,
-			"jwks_url":                config.JWKSURL,
-			"jwks_ca_pem":             config.JWKSCAPEM,
-			"bound_issuer":            config.BoundIssuer,
-			"provider_config":         config.ProviderConfig,
-			"pass_namespace_in_state": config.PassNamespaceInState,
+			"oidc_discovery_url":     config.OIDCDiscoveryURL,
+			"oidc_discovery_ca_pem":  config.OIDCDiscoveryCAPEM,
+			"oidc_client_id":         config.OIDCClientID,
+			"oidc_response_mode":     config.OIDCResponseMode,
+			"oidc_response_types":    config.OIDCResponseTypes,
+			"default_role":           config.DefaultRole,
+			"jwt_validation_pubkeys": config.JWTValidationPubKeys,
+			"jwt_supported_algs":     config.JWTSupportedAlgs,
+			"jwks_url":               config.JWKSURL,
+			"jwks_ca_pem":            config.JWKSCAPEM,
+			"bound_issuer":           config.BoundIssuer,
+			"provider_config":        config.ProviderConfig,
+			"namespace_in_state":     config.NamespaceInState,
 		},
 	}
 
@@ -198,7 +198,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		JWTSupportedAlgs:     d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:          d.Get("bound_issuer").(string),
 		ProviderConfig:       d.Get("provider_config").(map[string]interface{}),
-		PassNamespaceInState: d.Get("pass_namespace_in_state").(bool),
+		NamespaceInState:     d.Get("namespace_in_state").(bool),
 	}
 
 	// Run checks on values
@@ -361,7 +361,7 @@ type jwtConfig struct {
 	BoundIssuer          string                 `json:"bound_issuer"`
 	DefaultRole          string                 `json:"default_role"`
 	ProviderConfig       map[string]interface{} `json:"provider_config"`
-	PassNamespaceInState bool                   `json:"pass_namespace_in_state"`
+	NamespaceInState     bool                   `json:"namespace_in_state"`
 
 	ParsedJWTPubKeys []interface{} `json:"-"`
 }

--- a/path_config.go
+++ b/path_config.go
@@ -92,7 +92,11 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			"namespace_in_state": {
 				Type:        framework.TypeBool,
 				Description: "Pass namespace in the state parameter instead of as a separate query parameter. With this setting the allowed redirect URL in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it.",
-				Default:     false,
+				Default:     true,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "Namespace in state",
+					Value: true,
+				},
 			},
 		},
 

--- a/path_config.go
+++ b/path_config.go
@@ -94,6 +94,11 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 					},
 				},
 			},
+			"pass_namespace_in_state": {
+				Type:        framework.TypeBool,
+				Description: "Pass namespace in the state parameter instead of as a separate query parameter. With this setting the allowed redirect URL in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it.",
+				Default:     false,
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -159,18 +164,19 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"oidc_discovery_url":     config.OIDCDiscoveryURL,
-			"oidc_discovery_ca_pem":  config.OIDCDiscoveryCAPEM,
-			"oidc_client_id":         config.OIDCClientID,
-			"oidc_response_mode":     config.OIDCResponseMode,
-			"oidc_response_types":    config.OIDCResponseTypes,
-			"default_role":           config.DefaultRole,
-			"jwt_validation_pubkeys": config.JWTValidationPubKeys,
-			"jwt_supported_algs":     config.JWTSupportedAlgs,
-			"jwks_url":               config.JWKSURL,
-			"jwks_ca_pem":            config.JWKSCAPEM,
-			"bound_issuer":           config.BoundIssuer,
-			"provider_config":        config.ProviderConfig,
+			"oidc_discovery_url":      config.OIDCDiscoveryURL,
+			"oidc_discovery_ca_pem":   config.OIDCDiscoveryCAPEM,
+			"oidc_client_id":          config.OIDCClientID,
+			"oidc_response_mode":      config.OIDCResponseMode,
+			"oidc_response_types":     config.OIDCResponseTypes,
+			"default_role":            config.DefaultRole,
+			"jwt_validation_pubkeys":  config.JWTValidationPubKeys,
+			"jwt_supported_algs":      config.JWTSupportedAlgs,
+			"jwks_url":                config.JWKSURL,
+			"jwks_ca_pem":             config.JWKSCAPEM,
+			"bound_issuer":            config.BoundIssuer,
+			"provider_config":         config.ProviderConfig,
+			"pass_namespace_in_state": config.PassNamespaceInState,
 		},
 	}
 
@@ -192,6 +198,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		JWTSupportedAlgs:     d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:          d.Get("bound_issuer").(string),
 		ProviderConfig:       d.Get("provider_config").(map[string]interface{}),
+		PassNamespaceInState: d.Get("pass_namespace_in_state").(bool),
 	}
 
 	// Run checks on values
@@ -354,6 +361,7 @@ type jwtConfig struct {
 	BoundIssuer          string                 `json:"bound_issuer"`
 	DefaultRole          string                 `json:"default_role"`
 	ProviderConfig       map[string]interface{} `json:"provider_config"`
+	PassNamespaceInState bool                   `json:"pass_namespace_in_state"`
 
 	ParsedJWTPubKeys []interface{} `json:"-"`
 }

--- a/path_config.go
+++ b/path_config.go
@@ -93,7 +93,8 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Type:        framework.TypeBool,
 				Description: "Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.",
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Namespace in OIDC state",
+					Name:  "Namespace in OIDC state",
+					Value: true,
 				},
 			},
 		},
@@ -198,7 +199,8 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	}
 
 	// Check if the config already exists, to determine if this is a create or
-	// an update
+	// an update, since req.Operation is always 'update' in this handler, and
+	// there's no existence check defined.
 	existingConfig, err := b.config(ctx, req.Storage)
 	if err != nil {
 		return nil, err

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -16,18 +16,19 @@ func TestConfig_JWT_Read(t *testing.T) {
 	b, storage := getBackend(t)
 
 	data := map[string]interface{}{
-		"oidc_discovery_url":     "",
-		"oidc_discovery_ca_pem":  "",
-		"oidc_client_id":         "",
-		"oidc_response_mode":     "",
-		"oidc_response_types":    []string{},
-		"default_role":           "",
-		"jwt_validation_pubkeys": []string{testJWTPubKey},
-		"jwt_supported_algs":     []string{},
-		"jwks_url":               "",
-		"jwks_ca_pem":            "",
-		"bound_issuer":           "http://vault.example.com/",
-		"provider_config":        map[string]interface{}{},
+		"oidc_discovery_url":      "",
+		"oidc_discovery_ca_pem":   "",
+		"oidc_client_id":          "",
+		"oidc_response_mode":      "",
+		"oidc_response_types":     []string{},
+		"default_role":            "",
+		"jwt_validation_pubkeys":  []string{testJWTPubKey},
+		"jwt_supported_algs":      []string{},
+		"jwks_url":                "",
+		"jwks_ca_pem":             "",
+		"bound_issuer":            "http://vault.example.com/",
+		"provider_config":         map[string]interface{}{},
+		"pass_namespace_in_state": false,
 	}
 
 	req := &logical.Request{
@@ -160,18 +161,19 @@ func TestConfig_JWKS_Update(t *testing.T) {
 	}
 
 	data := map[string]interface{}{
-		"jwks_url":               s.server.URL + "/certs",
-		"jwks_ca_pem":            cert,
-		"oidc_discovery_url":     "",
-		"oidc_discovery_ca_pem":  "",
-		"oidc_client_id":         "",
-		"oidc_response_mode":     "form_post",
-		"oidc_response_types":    []string{},
-		"default_role":           "",
-		"jwt_validation_pubkeys": []string{},
-		"jwt_supported_algs":     []string{},
-		"bound_issuer":           "",
-		"provider_config":        map[string]interface{}{},
+		"jwks_url":                s.server.URL + "/certs",
+		"jwks_ca_pem":             cert,
+		"oidc_discovery_url":      "",
+		"oidc_discovery_ca_pem":   "",
+		"oidc_client_id":          "",
+		"oidc_response_mode":      "form_post",
+		"oidc_response_types":     []string{},
+		"default_role":            "",
+		"jwt_validation_pubkeys":  []string{},
+		"jwt_supported_algs":      []string{},
+		"bound_issuer":            "",
+		"provider_config":         map[string]interface{}{},
+		"pass_namespace_in_state": false,
 	}
 
 	req := &logical.Request{

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -508,6 +508,188 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 	})
 }
 
+func TestConfig_OIDC_Create_Namespace(t *testing.T) {
+	type testCase struct {
+		create   map[string]interface{}
+		expected jwtConfig
+	}
+	tests := map[string]testCase{
+		"namespace_in_state not specified": {
+			create: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     true,
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+		"namespace_in_state true": {
+			create: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": true,
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     true,
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+		"namespace_in_state false": {
+			create: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": false,
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     false,
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      test.create,
+			}
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)
+			assert.NoError(t, err)
+			assert.Equal(t, &test.expected, conf)
+		})
+	}
+
+}
+
+func TestConfig_OIDC_Update_Namespace(t *testing.T) {
+	type testCase struct {
+		existing map[string]interface{}
+		update   map[string]interface{}
+		expected jwtConfig
+	}
+	tests := map[string]testCase{
+		"existing false, update to true": {
+			existing: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": false,
+			},
+			update: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": true,
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     true,
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+		"existing false, update something else": {
+			existing: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": false,
+			},
+			update: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"default_role":       "ui",
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     false,
+				DefaultRole:          "ui",
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+		"existing true, update to false": {
+			existing: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": true,
+			},
+			update: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": false,
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     false,
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+		"existing true, update something else": {
+			existing: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"namespace_in_state": true,
+			},
+			update: map[string]interface{}{
+				"oidc_discovery_url": "https://team-vault.auth0.com/",
+				"default_role":       "ui",
+			},
+			expected: jwtConfig{
+				OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
+				NamespaceInState:     true,
+				DefaultRole:          "ui",
+				OIDCResponseTypes:    []string{},
+				JWTSupportedAlgs:     []string{},
+				JWTValidationPubKeys: []string{},
+				ProviderConfig:       map[string]interface{}{},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      test.existing,
+			}
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			req.Data = test.update
+			resp, err = b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)
+			assert.NoError(t, err)
+			assert.Equal(t, &test.expected, conf)
+		})
+	}
+
+}
+
 const (
 	testJWTPubKey = `-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEVs/o5+uQbTjL3chynL4wXgUg2R9

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -137,6 +137,7 @@ func TestConfig_JWT_Write(t *testing.T) {
 		OIDCResponseTypes:    []string{},
 		BoundIssuer:          "http://vault.example.com/",
 		ProviderConfig:       map[string]interface{}{},
+		NamespaceInState:     true,
 	}
 
 	conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)
@@ -344,6 +345,7 @@ func TestConfig_OIDC_Write(t *testing.T) {
 		OIDCResponseTypes:    []string{},
 		OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
 		ProviderConfig:       map[string]interface{}{},
+		NamespaceInState:     true,
 	}
 
 	conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)
@@ -435,6 +437,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 				"provider":     "azure",
 				"extraOptions": "abound",
 			},
+			NamespaceInState: true,
 		}
 
 		conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)
@@ -491,6 +494,7 @@ func TestConfig_OIDC_Write_ProviderConfig(t *testing.T) {
 			OIDCResponseTypes:    []string{},
 			OIDCDiscoveryURL:     "https://team-vault.auth0.com/",
 			ProviderConfig:       map[string]interface{}{},
+			NamespaceInState:     true,
 		}
 
 		conf, err := b.(*jwtAuthBackend).config(context.Background(), storage)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -16,19 +16,19 @@ func TestConfig_JWT_Read(t *testing.T) {
 	b, storage := getBackend(t)
 
 	data := map[string]interface{}{
-		"oidc_discovery_url":      "",
-		"oidc_discovery_ca_pem":   "",
-		"oidc_client_id":          "",
-		"oidc_response_mode":      "",
-		"oidc_response_types":     []string{},
-		"default_role":            "",
-		"jwt_validation_pubkeys":  []string{testJWTPubKey},
-		"jwt_supported_algs":      []string{},
-		"jwks_url":                "",
-		"jwks_ca_pem":             "",
-		"bound_issuer":            "http://vault.example.com/",
-		"provider_config":         map[string]interface{}{},
-		"pass_namespace_in_state": false,
+		"oidc_discovery_url":     "",
+		"oidc_discovery_ca_pem":  "",
+		"oidc_client_id":         "",
+		"oidc_response_mode":     "",
+		"oidc_response_types":    []string{},
+		"default_role":           "",
+		"jwt_validation_pubkeys": []string{testJWTPubKey},
+		"jwt_supported_algs":     []string{},
+		"jwks_url":               "",
+		"jwks_ca_pem":            "",
+		"bound_issuer":           "http://vault.example.com/",
+		"provider_config":        map[string]interface{}{},
+		"namespace_in_state":     false,
 	}
 
 	req := &logical.Request{
@@ -161,19 +161,19 @@ func TestConfig_JWKS_Update(t *testing.T) {
 	}
 
 	data := map[string]interface{}{
-		"jwks_url":                s.server.URL + "/certs",
-		"jwks_ca_pem":             cert,
-		"oidc_discovery_url":      "",
-		"oidc_discovery_ca_pem":   "",
-		"oidc_client_id":          "",
-		"oidc_response_mode":      "form_post",
-		"oidc_response_types":     []string{},
-		"default_role":            "",
-		"jwt_validation_pubkeys":  []string{},
-		"jwt_supported_algs":      []string{},
-		"bound_issuer":            "",
-		"provider_config":         map[string]interface{}{},
-		"pass_namespace_in_state": false,
+		"jwks_url":               s.server.URL + "/certs",
+		"jwks_ca_pem":            cert,
+		"oidc_discovery_url":     "",
+		"oidc_discovery_ca_pem":  "",
+		"oidc_client_id":         "",
+		"oidc_response_mode":     "form_post",
+		"oidc_response_types":    []string{},
+		"default_role":           "",
+		"jwt_validation_pubkeys": []string{},
+		"jwt_supported_algs":     []string{},
+		"bound_issuer":           "",
+		"provider_config":        map[string]interface{}{},
+		"namespace_in_state":     false,
 	}
 
 	req := &logical.Request{

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -373,7 +373,7 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 
 	// If namespace will be passed around in state, don't store it in redirect_uri
 	namespace := ""
-	if config.PassNamespaceInState {
+	if config.NamespaceInState {
 		inputURI, err := url.Parse(redirectURI)
 		if err != nil {
 			return resp, nil
@@ -422,7 +422,7 @@ func (b *jwtAuthBackend) authURL(ctx context.Context, req *logical.Request, d *f
 		logger.Warn("error generating OAuth state", "error", err)
 		return resp, nil
 	}
-	if config.PassNamespaceInState && len(namespace) > 0 {
+	if config.NamespaceInState && len(namespace) > 0 {
 		// embed namespace in state in the auth_url
 		stateID = fmt.Sprintf("%s,ns=%s", stateID, namespace)
 	}

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -208,6 +208,163 @@ func TestOIDC_AuthURL(t *testing.T) {
 	})
 }
 
+func TestOIDC_AuthURL_namespace(t *testing.T) {
+
+	type testCase struct {
+		passNamespaceInState string
+		allowedRedirectURIs  []string
+		incomingRedirectURI  string
+		expectedStateRegEx   string
+		expectedRedirectURI  string
+		expectFail           bool
+	}
+
+	tests := map[string]testCase{
+		"namespace as query parameter": {
+			passNamespaceInState: "false",
+			allowedRedirectURIs:  []string{"https://example.com?namespace=test"},
+			incomingRedirectURI:  "https://example.com?namespace=test",
+			expectedStateRegEx:   `\w{27}`,
+			expectedRedirectURI:  `https://example.com?namespace=test`,
+		},
+		"namespace as query parameter, bad allowed redirect": {
+			passNamespaceInState: "false",
+			allowedRedirectURIs:  []string{"https://example.com"},
+			incomingRedirectURI:  "https://example.com?namespace=test",
+			expectedStateRegEx:   `\w{27}`,
+			expectedRedirectURI:  `https://example.com?namespace=test`,
+			expectFail:           true,
+		},
+		"namespace in state": {
+			passNamespaceInState: "true",
+			allowedRedirectURIs:  []string{"https://example.com"},
+			incomingRedirectURI:  "https://example.com?namespace=test",
+			expectedStateRegEx:   `\w{27},ns=test`,
+			expectedRedirectURI:  `https://example.com`,
+		},
+		"namespace in state, bad allowed redirect": {
+			passNamespaceInState: "true",
+			allowedRedirectURIs:  []string{"https://example.com?namespace=test"},
+			incomingRedirectURI:  "https://example.com?namespace=test",
+			expectFail:           true,
+		},
+		"nested namespace in state": {
+			passNamespaceInState: "true",
+			allowedRedirectURIs:  []string{"https://example.com"},
+			incomingRedirectURI:  "https://example.com?namespace=org4321/dev",
+			expectedStateRegEx:   `\w{27},ns=org4321/dev`,
+			expectedRedirectURI:  `https://example.com`,
+		},
+		"namespace as query parameter, no namespaces": {
+			passNamespaceInState: "false",
+			allowedRedirectURIs:  []string{"https://example.com"},
+			incomingRedirectURI:  "https://example.com",
+			expectedStateRegEx:   `\w{27}`,
+			expectedRedirectURI:  `https://example.com`,
+		},
+		"namespace in state, no namespaces": {
+			passNamespaceInState: "true",
+			allowedRedirectURIs:  []string{"https://example.com"},
+			incomingRedirectURI:  "https://example.com",
+			expectedStateRegEx:   `\w{27}`,
+			expectedRedirectURI:  `https://example.com`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+
+			// Configure backend
+			data := map[string]interface{}{
+				"oidc_discovery_url":      "https://team-vault.auth0.com/",
+				"oidc_discovery_ca_pem":   "",
+				"oidc_client_id":          "abc",
+				"oidc_client_secret":      "def",
+				"default_role":            "test",
+				"bound_issuer":            "http://vault.example.com/",
+				"pass_namespace_in_state": test.passNamespaceInState,
+			}
+
+			// basic configuration
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      data,
+			}
+
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v\n", err, resp)
+			}
+
+			// set up test role
+			rolePayload := map[string]interface{}{
+				"user_claim":            "email",
+				"bound_audiences":       "vault",
+				"allowed_redirect_uris": test.allowedRedirectURIs,
+			}
+
+			req = &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      "role/test",
+				Storage:   storage,
+				Data:      rolePayload,
+			}
+
+			resp, err = b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v\n", err, resp)
+			}
+
+			authURLPayload := map[string]interface{}{
+				"role":         "test",
+				"redirect_uri": test.incomingRedirectURI,
+			}
+			req = &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      "oidc/auth_url",
+				Storage:   storage,
+				Data:      authURLPayload,
+			}
+
+			resp, err = b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%v resp:%#v\n", err, resp)
+			}
+
+			rawAuthURL := resp.Data["auth_url"].(string)
+			if test.expectFail && len(rawAuthURL) > 0 {
+				t.Fatalf("Expected auth_url to fail (empty), but got %s", rawAuthURL)
+			}
+			if test.expectFail && len(rawAuthURL) == 0 {
+				return
+			}
+
+			authURL, err := url.Parse(rawAuthURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			qParams := authURL.Query()
+			redirectURI := qParams.Get("redirect_uri")
+			if test.expectedRedirectURI != redirectURI {
+				t.Fatalf("expected redirect_uri to match: %s, %s", test.expectedRedirectURI, redirectURI)
+			}
+
+			state := qParams.Get("state")
+			matchState, err := regexp.MatchString(test.expectedStateRegEx, state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !matchState {
+				t.Fatalf("expected state to match regex: %s, %s", test.expectedStateRegEx, state)
+			}
+
+		})
+	}
+}
+
 func TestOIDC_Callback(t *testing.T) {
 	t.Run("successful login", func(t *testing.T) {
 

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -211,63 +211,63 @@ func TestOIDC_AuthURL(t *testing.T) {
 func TestOIDC_AuthURL_namespace(t *testing.T) {
 
 	type testCase struct {
-		passNamespaceInState string
-		allowedRedirectURIs  []string
-		incomingRedirectURI  string
-		expectedStateRegEx   string
-		expectedRedirectURI  string
-		expectFail           bool
+		namespaceInState    string
+		allowedRedirectURIs []string
+		incomingRedirectURI string
+		expectedStateRegEx  string
+		expectedRedirectURI string
+		expectFail          bool
 	}
 
 	tests := map[string]testCase{
 		"namespace as query parameter": {
-			passNamespaceInState: "false",
-			allowedRedirectURIs:  []string{"https://example.com?namespace=test"},
-			incomingRedirectURI:  "https://example.com?namespace=test",
-			expectedStateRegEx:   `\w{27}`,
-			expectedRedirectURI:  `https://example.com?namespace=test`,
+			namespaceInState:    "false",
+			allowedRedirectURIs: []string{"https://example.com?namespace=test"},
+			incomingRedirectURI: "https://example.com?namespace=test",
+			expectedStateRegEx:  `\w{27}`,
+			expectedRedirectURI: `https://example.com?namespace=test`,
 		},
 		"namespace as query parameter, bad allowed redirect": {
-			passNamespaceInState: "false",
-			allowedRedirectURIs:  []string{"https://example.com"},
-			incomingRedirectURI:  "https://example.com?namespace=test",
-			expectedStateRegEx:   `\w{27}`,
-			expectedRedirectURI:  `https://example.com?namespace=test`,
-			expectFail:           true,
+			namespaceInState:    "false",
+			allowedRedirectURIs: []string{"https://example.com"},
+			incomingRedirectURI: "https://example.com?namespace=test",
+			expectedStateRegEx:  `\w{27}`,
+			expectedRedirectURI: `https://example.com?namespace=test`,
+			expectFail:          true,
 		},
 		"namespace in state": {
-			passNamespaceInState: "true",
-			allowedRedirectURIs:  []string{"https://example.com"},
-			incomingRedirectURI:  "https://example.com?namespace=test",
-			expectedStateRegEx:   `\w{27},ns=test`,
-			expectedRedirectURI:  `https://example.com`,
+			namespaceInState:    "true",
+			allowedRedirectURIs: []string{"https://example.com"},
+			incomingRedirectURI: "https://example.com?namespace=test",
+			expectedStateRegEx:  `\w{27},ns=test`,
+			expectedRedirectURI: `https://example.com`,
 		},
 		"namespace in state, bad allowed redirect": {
-			passNamespaceInState: "true",
-			allowedRedirectURIs:  []string{"https://example.com?namespace=test"},
-			incomingRedirectURI:  "https://example.com?namespace=test",
-			expectFail:           true,
+			namespaceInState:    "true",
+			allowedRedirectURIs: []string{"https://example.com?namespace=test"},
+			incomingRedirectURI: "https://example.com?namespace=test",
+			expectFail:          true,
 		},
 		"nested namespace in state": {
-			passNamespaceInState: "true",
-			allowedRedirectURIs:  []string{"https://example.com"},
-			incomingRedirectURI:  "https://example.com?namespace=org4321/dev",
-			expectedStateRegEx:   `\w{27},ns=org4321/dev`,
-			expectedRedirectURI:  `https://example.com`,
+			namespaceInState:    "true",
+			allowedRedirectURIs: []string{"https://example.com"},
+			incomingRedirectURI: "https://example.com?namespace=org4321/dev",
+			expectedStateRegEx:  `\w{27},ns=org4321/dev`,
+			expectedRedirectURI: `https://example.com`,
 		},
 		"namespace as query parameter, no namespaces": {
-			passNamespaceInState: "false",
-			allowedRedirectURIs:  []string{"https://example.com"},
-			incomingRedirectURI:  "https://example.com",
-			expectedStateRegEx:   `\w{27}`,
-			expectedRedirectURI:  `https://example.com`,
+			namespaceInState:    "false",
+			allowedRedirectURIs: []string{"https://example.com"},
+			incomingRedirectURI: "https://example.com",
+			expectedStateRegEx:  `\w{27}`,
+			expectedRedirectURI: `https://example.com`,
 		},
 		"namespace in state, no namespaces": {
-			passNamespaceInState: "true",
-			allowedRedirectURIs:  []string{"https://example.com"},
-			incomingRedirectURI:  "https://example.com",
-			expectedStateRegEx:   `\w{27}`,
-			expectedRedirectURI:  `https://example.com`,
+			namespaceInState:    "true",
+			allowedRedirectURIs: []string{"https://example.com"},
+			incomingRedirectURI: "https://example.com",
+			expectedStateRegEx:  `\w{27}`,
+			expectedRedirectURI: `https://example.com`,
 		},
 	}
 
@@ -277,13 +277,13 @@ func TestOIDC_AuthURL_namespace(t *testing.T) {
 
 			// Configure backend
 			data := map[string]interface{}{
-				"oidc_discovery_url":      "https://team-vault.auth0.com/",
-				"oidc_discovery_ca_pem":   "",
-				"oidc_client_id":          "abc",
-				"oidc_client_secret":      "def",
-				"default_role":            "test",
-				"bound_issuer":            "http://vault.example.com/",
-				"pass_namespace_in_state": test.passNamespaceInState,
+				"oidc_discovery_url":    "https://team-vault.auth0.com/",
+				"oidc_discovery_ca_pem": "",
+				"oidc_client_id":        "abc",
+				"oidc_client_secret":    "def",
+				"default_role":          "test",
+				"bound_issuer":          "http://vault.example.com/",
+				"namespace_in_state":    test.namespaceInState,
 			}
 
 			// basic configuration


### PR DESCRIPTION
# Overview
Add an option to the OIDC config to pass namespace in the state parameter instead of as a separate query parameter. With this setting the allowed redirect URL in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it.

To test this, I've been doing something like this along with the vault PR https://github.com/hashicorp/vault/pull/10171:

  - `yarn start` in the vault/ui directory to start the UI in live-reloading/dev mode
  - `./scripts/local_dev.sh` in this vault-plugin-auth-jwt repo, with a vault enterprise binary in your path
  - visit the UI at http://localhost:4200/

# Design of Change
A config option in the OIDC config

# Related Issues/Pull Requests
- [x] https://github.com/hashicorp/vault/pull/10171

# Contributor Checklist
- [x] Docs included in this PR: https://github.com/hashicorp/vault/pull/10171
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

<details>

```
❯ make test TESTARGS="-count=1" 
VAULT_ACC=1 go test -tags='vault-plugin-auth-jwt' $(go list ./... | grep -v /vendor/) -v -count=1 -timeout 10m
=== RUN   TestGetClaim
--- PASS: TestGetClaim (0.00s)
=== RUN   TestExtractMetadata
--- PASS: TestExtractMetadata (0.00s)
=== RUN   TestValidateAudience
--- PASS: TestValidateAudience (0.00s)
=== RUN   TestValidateBoundClaims
--- PASS: TestValidateBoundClaims (0.00s)
=== RUN   Test_normalizeList
--- PASS: Test_normalizeList (0.00s)
=== RUN   TestParseHelp
=== RUN   TestParseHelp/#00
=== RUN   TestParseHelp/#01
=== RUN   TestParseHelp/#02
=== RUN   TestParseHelp/#03
=== RUN   TestParseHelp/#04
=== RUN   TestParseHelp/#05
--- PASS: TestParseHelp (0.00s)
    --- PASS: TestParseHelp/#00 (0.00s)
    --- PASS: TestParseHelp/#01 (0.00s)
    --- PASS: TestParseHelp/#02 (0.00s)
    --- PASS: TestParseHelp/#03 (0.00s)
    --- PASS: TestParseHelp/#04 (0.00s)
    --- PASS: TestParseHelp/#05 (0.00s)
=== RUN   TestConfig_JWT_Read
--- PASS: TestConfig_JWT_Read (0.00s)
=== RUN   TestConfig_JWT_Write
--- PASS: TestConfig_JWT_Write (0.00s)
=== RUN   TestConfig_JWKS_Update
--- PASS: TestConfig_JWKS_Update (0.00s)
=== RUN   TestConfig_JWKS_Update_Invalid
--- PASS: TestConfig_JWKS_Update_Invalid (0.00s)
=== RUN   TestConfig_ResponseMode
--- PASS: TestConfig_ResponseMode (0.00s)
=== RUN   TestConfig_OIDC_Write
--- PASS: TestConfig_OIDC_Write (0.31s)
=== RUN   TestConfig_OIDC_Write_ProviderConfig
=== RUN   TestConfig_OIDC_Write_ProviderConfig/valid_provider_config
=== RUN   TestConfig_OIDC_Write_ProviderConfig/unknown_provider_in_provider_config
=== RUN   TestConfig_OIDC_Write_ProviderConfig/provider_config_missing_provider
=== RUN   TestConfig_OIDC_Write_ProviderConfig/provider_config_not_set
--- PASS: TestConfig_OIDC_Write_ProviderConfig (0.11s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/valid_provider_config (0.03s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/unknown_provider_in_provider_config (0.03s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/provider_config_missing_provider (0.03s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/provider_config_not_set (0.02s)
=== RUN   TestLogin_JWT
--- PASS: TestLogin_JWT (0.02s)
=== RUN   TestLogin_Leeways
--- PASS: TestLogin_Leeways (0.17s)
=== RUN   TestLogin_OIDC
2020-10-26T14:21:59.920-0700 [WARN]  unable to locate /org/primary in claims: /org/primary at part 0: couldn't find key "org"
--- PASS: TestLogin_OIDC (0.30s)
=== RUN   TestLogin_NestedGroups
--- PASS: TestLogin_NestedGroups (0.00s)
=== RUN   TestLogin_OIDC_StringGroupClaim
2020-10-26T14:22:00.079-0700 [WARN]  unable to locate /org/primary in claims: /org/primary at part 0: couldn't find key "org"
--- PASS: TestLogin_OIDC_StringGroupClaim (0.16s)
=== RUN   TestLogin_JWKS_Concurrent
--- PASS: TestLogin_JWKS_Concurrent (0.25s)
=== RUN   TestOIDC_AuthURL
=== RUN   TestOIDC_AuthURL/normal_case
=== PAUSE TestOIDC_AuthURL/normal_case
=== RUN   TestOIDC_AuthURL/missing_role
=== PAUSE TestOIDC_AuthURL/missing_role
=== RUN   TestOIDC_AuthURL/valid_redirect_uri
=== PAUSE TestOIDC_AuthURL/valid_redirect_uri
=== RUN   TestOIDC_AuthURL/invalid_redirect_uri
=== PAUSE TestOIDC_AuthURL/invalid_redirect_uri
=== CONT  TestOIDC_AuthURL/normal_case
=== CONT  TestOIDC_AuthURL/valid_redirect_uri
=== CONT  TestOIDC_AuthURL/invalid_redirect_uri
=== CONT  TestOIDC_AuthURL/missing_role
2020-10-26T14:22:00.355-0700 [WARN]  unauthorized redirect_uri: redirect_uri=http://bitc0in-4-less.cx
--- PASS: TestOIDC_AuthURL (0.02s)
    --- PASS: TestOIDC_AuthURL/invalid_redirect_uri (0.00s)
    --- PASS: TestOIDC_AuthURL/valid_redirect_uri (0.02s)
    --- PASS: TestOIDC_AuthURL/missing_role (0.02s)
    --- PASS: TestOIDC_AuthURL/normal_case (0.02s)
=== RUN   TestOIDC_AuthURL_namespace
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_bad_allowed_redirect
2020-10-26T14:22:00.453-0700 [WARN]  unauthorized redirect_uri: redirect_uri=https://example.com?namespace=test
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state,_bad_allowed_redirect
2020-10-26T14:22:00.523-0700 [WARN]  unauthorized redirect_uri: redirect_uri=https://example.com
=== RUN   TestOIDC_AuthURL_namespace/nested_namespace_in_state
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_no_namespaces
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state,_no_namespaces
--- PASS: TestOIDC_AuthURL_namespace (0.29s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter (0.05s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_bad_allowed_redirect (0.02s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state (0.05s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state,_bad_allowed_redirect (0.02s)
    --- PASS: TestOIDC_AuthURL_namespace/nested_namespace_in_state (0.05s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_no_namespaces (0.05s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state,_no_namespaces (0.05s)
=== RUN   TestOIDC_Callback
=== RUN   TestOIDC_Callback/successful_login
=== RUN   TestOIDC_Callback/failed_login_-_bad_nonce
=== RUN   TestOIDC_Callback/failed_login_-_bound_claim_mismatch
=== RUN   TestOIDC_Callback/missing_state
=== RUN   TestOIDC_Callback/unknown_state
=== RUN   TestOIDC_Callback/valid_state,_missing_code
=== RUN   TestOIDC_Callback/failed_code_exchange
=== RUN   TestOIDC_Callback/no_response_from_provider
=== RUN   TestOIDC_Callback/test_bad_address
=== RUN   TestOIDC_Callback/test_invalid_client_id
=== RUN   TestOIDC_Callback/client_nonce
--- PASS: TestOIDC_Callback (0.05s)
    --- PASS: TestOIDC_Callback/successful_login (0.01s)
    --- PASS: TestOIDC_Callback/failed_login_-_bad_nonce (0.00s)
    --- PASS: TestOIDC_Callback/failed_login_-_bound_claim_mismatch (0.00s)
    --- PASS: TestOIDC_Callback/missing_state (0.00s)
    --- PASS: TestOIDC_Callback/unknown_state (0.00s)
    --- PASS: TestOIDC_Callback/valid_state,_missing_code (0.00s)
    --- PASS: TestOIDC_Callback/failed_code_exchange (0.00s)
    --- PASS: TestOIDC_Callback/no_response_from_provider (0.00s)
    --- PASS: TestOIDC_Callback/test_bad_address (0.00s)
    --- PASS: TestOIDC_Callback/test_invalid_client_id (0.00s)
    --- PASS: TestOIDC_Callback/client_nonce (0.01s)
=== RUN   TestOIDC_ValidRedirect
--- PASS: TestOIDC_ValidRedirect (0.00s)
=== RUN   TestParseMount
--- PASS: TestParseMount (0.00s)
=== RUN   TestPath_Create
=== RUN   TestPath_Create/happy_path
=== RUN   TestPath_Create/no_user_claim
=== RUN   TestPath_Create/no_binding
=== RUN   TestPath_Create/has_bound_subject
=== RUN   TestPath_Create/has_audience
=== RUN   TestPath_Create/has_cidr
=== RUN   TestPath_Create/has_bound_claims
=== RUN   TestPath_Create/has_expiration,_not_before_custom_leeways
=== RUN   TestPath_Create/storing_zero_leeways
=== RUN   TestPath_Create/storing_negative_leeways
=== RUN   TestPath_Create/storing_an_invalid_bound_claim_type
=== RUN   TestPath_Create/role_with_invalid_glob_in_claim
=== RUN   TestPath_Create/role_with_invalid_glob_in_claim_array
--- PASS: TestPath_Create (0.00s)
    --- PASS: TestPath_Create/happy_path (0.00s)
    --- PASS: TestPath_Create/no_user_claim (0.00s)
    --- PASS: TestPath_Create/no_binding (0.00s)
    --- PASS: TestPath_Create/has_bound_subject (0.00s)
    --- PASS: TestPath_Create/has_audience (0.00s)
    --- PASS: TestPath_Create/has_cidr (0.00s)
    --- PASS: TestPath_Create/has_bound_claims (0.00s)
    --- PASS: TestPath_Create/has_expiration,_not_before_custom_leeways (0.00s)
    --- PASS: TestPath_Create/storing_zero_leeways (0.00s)
    --- PASS: TestPath_Create/storing_negative_leeways (0.00s)
    --- PASS: TestPath_Create/storing_an_invalid_bound_claim_type (0.00s)
    --- PASS: TestPath_Create/role_with_invalid_glob_in_claim (0.00s)
    --- PASS: TestPath_Create/role_with_invalid_glob_in_claim_array (0.00s)
=== RUN   TestPath_OIDCCreate
=== RUN   TestPath_OIDCCreate/both_explicit_and_default_role_type
=== RUN   TestPath_OIDCCreate/invalid_reserved_metadata_key_role
=== RUN   TestPath_OIDCCreate/invalid_duplicate_metadata_destination
=== RUN   TestPath_OIDCCreate/custom_expiration_leeway_and_not_before_leeway_values
--- PASS: TestPath_OIDCCreate (0.00s)
    --- PASS: TestPath_OIDCCreate/both_explicit_and_default_role_type (0.00s)
    --- PASS: TestPath_OIDCCreate/invalid_reserved_metadata_key_role (0.00s)
    --- PASS: TestPath_OIDCCreate/invalid_duplicate_metadata_destination (0.00s)
    --- PASS: TestPath_OIDCCreate/custom_expiration_leeway_and_not_before_leeway_values (0.00s)
=== RUN   TestPath_Read
--- PASS: TestPath_Read (0.00s)
=== RUN   TestPath_Delete
--- PASS: TestPath_Delete (0.00s)
=== RUN   TestLogin_fetchGroups
2020-10-26T14:22:00.728-0700 [DEBUG] found Azure Graph API endpoint for group membership: https://127.0.0.1:57319/getMemberObjects
2020-10-26T14:22:00.731-0700 [DEBUG] groups claim raw is [group1 group2]
--- PASS: TestLogin_fetchGroups (0.00s)
=== RUN   Test_getClaimSources
=== RUN   Test_getClaimSources/normal_case
=== RUN   Test_getClaimSources/no__claim_names
2020-10-26T14:22:00.731-0700 [WARN]  unable to locate /_claim_names/groups in claims: /_claim_names/groups at part 0: couldn't find key "_claim_names"
=== RUN   Test_getClaimSources/no__claim_sources
2020-10-26T14:22:00.731-0700 [WARN]  unable to locate /_claim_sources/src1/endpoint in claims: /_claim_sources/src1/endpoint at part 0: couldn't find key "_claim_sources"
--- PASS: Test_getClaimSources (0.00s)
    --- PASS: Test_getClaimSources/normal_case (0.00s)
    --- PASS: Test_getClaimSources/no__claim_names (0.00s)
    --- PASS: Test_getClaimSources/no__claim_sources (0.00s)
=== RUN   TestNewProviderConfig
=== RUN   TestNewProviderConfig/normal_case
=== RUN   TestNewProviderConfig/no_provider_config
=== RUN   TestNewProviderConfig/provider_field_not_present_in_provider_config
=== RUN   TestNewProviderConfig/unknown_provider
=== RUN   TestNewProviderConfig/provider_name_not_present_in_provider_config
=== RUN   TestNewProviderConfig/error_in_Initialize
--- PASS: TestNewProviderConfig (0.00s)
    --- PASS: TestNewProviderConfig/normal_case (0.00s)
    --- PASS: TestNewProviderConfig/no_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/provider_field_not_present_in_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/unknown_provider (0.00s)
    --- PASS: TestNewProviderConfig/provider_name_not_present_in_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/error_in_Initialize (0.00s)
=== RUN   TestGSuiteProvider_FetchGroups
    provider_gsuite_test.go:27: skip: must set env var "GOOGLE_CREDENTIALS" to a valid service account key file path
--- SKIP: TestGSuiteProvider_FetchGroups (0.00s)
=== RUN   TestGSuiteProvider_FetchUserInfo
    provider_gsuite_test.go:27: skip: must set env var "GOOGLE_CREDENTIALS" to a valid service account key file path
--- SKIP: TestGSuiteProvider_FetchUserInfo (0.00s)
=== RUN   TestGSuiteProvider_search
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_that's_in_no_groups
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_that's_in_no_groups
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_default_recursion_max_depth_0
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_1
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_10
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_default_recursion_max_depth_0
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_1
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_10
--- PASS: TestGSuiteProvider_search (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_that's_in_no_groups (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_that's_in_no_groups (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_default_recursion_max_depth_0 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_1 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_10 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_default_recursion_max_depth_0 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_1 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_10 (0.00s)
=== RUN   TestGSuiteProvider_initialize
=== RUN   TestGSuiteProvider_initialize/invalid_config:_required_service_account_key_is_empty
=== RUN   TestGSuiteProvider_initialize/invalid_config:_required_admin_impersonate_email_is_empty
=== RUN   TestGSuiteProvider_initialize/invalid_config:_recurse_max_depth_negative_number
=== RUN   TestGSuiteProvider_initialize/valid_config:_all_options
=== RUN   TestGSuiteProvider_initialize/valid_config:_no_custom_schemas
=== RUN   TestGSuiteProvider_initialize/valid_config:_no_recurse_max_depth
=== RUN   TestGSuiteProvider_initialize/valid_config:_fetch_groups_and_user_info
--- PASS: TestGSuiteProvider_initialize (0.00s)
    --- PASS: TestGSuiteProvider_initialize/invalid_config:_required_service_account_key_is_empty (0.00s)
    --- PASS: TestGSuiteProvider_initialize/invalid_config:_required_admin_impersonate_email_is_empty (0.00s)
    --- PASS: TestGSuiteProvider_initialize/invalid_config:_recurse_max_depth_negative_number (0.00s)
    --- PASS: TestGSuiteProvider_initialize/valid_config:_all_options (0.00s)
    --- PASS: TestGSuiteProvider_initialize/valid_config:_no_custom_schemas (0.00s)
    --- PASS: TestGSuiteProvider_initialize/valid_config:_no_recurse_max_depth (0.00s)
    --- PASS: TestGSuiteProvider_initialize/valid_config:_fetch_groups_and_user_info (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-auth-jwt	1.969s
?   	github.com/hashicorp/vault-plugin-auth-jwt/cmd/vault-plugin-auth-jwt	[no test files]
```

</details>

- [x] Backwards compatible
