### PR TITLE
Remove provider_config DisplayAttrs.Value

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -87,11 +87,6 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Description: "Provider-specific configuration. Optional.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Provider Config",
-					Value: map[string]interface{}{
-						"provider":               "gsuite",
-						"fetch_groups":           true,
-						"gsuite_service_account": "ey4921...",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
# Overview
Remove provider_config DisplayAttrs.Value, since that is treated as the default by the UI, and the default should
be empty. This was causing issues with the UI.

# Contributor Checklist
- [x] Backwards compatible
