### PR TITLE
Backport 1.6.x: Remove provider_config DisplayAttrs.Value (#141)

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -87,11 +87,6 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Description: "Provider-specific configuration. Optional.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Provider Config",
-					Value: map[string]interface{}{
-						"provider":               "gsuite",
-						"fetch_groups":           true,
-						"gsuite_service_account": "ey4921...",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
Backporting https://github.com/hashicorp/vault-plugin-auth-jwt/pull/141 to 1.6 branch.