### PR TITLE
Fixes bound_claims validation for provider-specific group and user info fetching

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -303,7 +303,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	}
 
 	// Validate provider_config
-	if _, err := NewProviderConfig(config, ProviderMap()); err != nil {
+	if _, err := NewProviderConfig(ctx, config, ProviderMap()); err != nil {
 		return logical.ErrorResponse("invalid provider_config: %s", err), nil
 	}
 

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -280,13 +280,13 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 	}
 
-	if err := validateBoundClaims(b.Logger(), role.BoundClaimsType, role.BoundClaims, allClaims); err != nil {
-		return logical.ErrorResponse("error validating claims: %s", err.Error()), nil
-	}
-
-	alias, groupAliases, err := b.createIdentity(allClaims, role)
+	alias, groupAliases, err := b.createIdentity(ctx, allClaims, role)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	if err := validateBoundClaims(b.Logger(), role.BoundClaimsType, role.BoundClaims, allClaims); err != nil {
+		return logical.ErrorResponse("error validating claims: %s", err.Error()), nil
 	}
 
 	tokenMetadata := map[string]string{"role": roleName}

--- a/provider_azure.go
+++ b/provider_azure.go
@@ -35,7 +35,7 @@ type AzureProvider struct {
 }
 
 // Initialize anything in the AzureProvider struct - satisfying the CustomProvider interface
-func (a *AzureProvider) Initialize(jc *jwtConfig) error {
+func (a *AzureProvider) Initialize(_ context.Context, _ *jwtConfig) error {
 	return nil
 }
 
@@ -45,7 +45,7 @@ func (a *AzureProvider) SensitiveKeys() []string {
 }
 
 // FetchGroups - custom groups fetching for azure - satisfying GroupsFetcher interface
-func (a *AzureProvider) FetchGroups(b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) (interface{}, error) {
+func (a *AzureProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) (interface{}, error) {
 	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
 
 	if groupsClaimRaw == nil {

--- a/provider_config_test.go
+++ b/provider_config_test.go
@@ -1,6 +1,7 @@
 package jwtauth
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,7 +13,7 @@ type testProviderConfig struct {
 	throwError  bool
 }
 
-func (t *testProviderConfig) Initialize(jc *jwtConfig) error {
+func (t *testProviderConfig) Initialize(_ context.Context, jc *jwtConfig) error {
 	if t.throwError {
 		return fmt.Errorf("i'm throwing an error")
 	}
@@ -37,7 +38,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"test": &testProviderConfig{},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.NoError(t, err)
 		assert.Equal(t, "yes", theProvider.(*testProviderConfig).initialized)
 
@@ -51,7 +52,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"test": &testProviderConfig{},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.NoError(t, err)
 		assert.Nil(t, theProvider)
 	})
@@ -66,7 +67,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"test": &testProviderConfig{},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.EqualError(t, err, "'provider' field not found in provider_config")
 		assert.Nil(t, theProvider)
 	})
@@ -82,7 +83,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"not-test": &testProviderConfig{},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.EqualError(t, err, "provider \"test\" not found in custom providers")
 		assert.Nil(t, theProvider)
 	})
@@ -97,7 +98,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"test": &testProviderConfig{},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.EqualError(t, err, "'provider' field not found in provider_config")
 		assert.Nil(t, theProvider)
 	})
@@ -113,7 +114,7 @@ func TestNewProviderConfig(t *testing.T) {
 			"test": &testProviderConfig{throwError: true},
 		}
 
-		theProvider, err := NewProviderConfig(jc, pMap)
+		theProvider, err := NewProviderConfig(context.Background(), jc, pMap)
 		assert.EqualError(t, err, "error initializing \"test\" provider_config: i'm throwing an error")
 		assert.Nil(t, theProvider)
 	})

--- a/provider_gsuite.go
+++ b/provider_gsuite.go
@@ -46,7 +46,7 @@ type GSuiteProviderConfig struct {
 }
 
 // Initialize initializes the GSuiteProvider by validating and creating configuration.
-func (g *GSuiteProvider) Initialize(jc *jwtConfig) error {
+func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 	// Decode the provider config
 	var config GSuiteProviderConfig
 	if err := mapstructure.Decode(jc.ProviderConfig, &config); err != nil {
@@ -60,10 +60,10 @@ func (g *GSuiteProvider) Initialize(jc *jwtConfig) error {
 	}
 	config.serviceAccountKeyJSON = keyJSON
 
-	return g.initialize(config)
+	return g.initialize(ctx, config)
 }
 
-func (g *GSuiteProvider) initialize(config GSuiteProviderConfig) error {
+func (g *GSuiteProvider) initialize(ctx context.Context, config GSuiteProviderConfig) error {
 	var err error
 
 	// Validate configuration
@@ -88,6 +88,13 @@ func (g *GSuiteProvider) initialize(config GSuiteProviderConfig) error {
 	// Set the subject to impersonate and config
 	g.jwtConfig.Subject = config.AdminImpersonateEmail
 	g.config = config
+
+	// Create a new admin service for requests to Google admin APIs
+	g.adminSvc, err = admin.NewService(ctx, option.WithHTTPClient(g.jwtConfig.Client(ctx)))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -97,7 +104,7 @@ func (g *GSuiteProvider) SensitiveKeys() []string {
 }
 
 // FetchGroups fetches and returns groups from G Suite.
-func (g *GSuiteProvider) FetchGroups(b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) (interface{}, error) {
+func (g *GSuiteProvider) FetchGroups(ctx context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) (interface{}, error) {
 	if !g.config.FetchGroups {
 		return nil, nil
 	}
@@ -107,15 +114,9 @@ func (g *GSuiteProvider) FetchGroups(b *jwtAuthBackend, allClaims map[string]int
 		return nil, err
 	}
 
-	// Set context and create a new admin service for requests to Google admin APIs
-	g.adminSvc, err = admin.NewService(b.providerCtx, option.WithHTTPClient(g.jwtConfig.Client(b.providerCtx)))
-	if err != nil {
-		return nil, err
-	}
-
 	// Get the G Suite groups
 	userGroupsMap := make(map[string]bool)
-	if err := g.search(b.providerCtx, userGroupsMap, userName, g.config.GroupsRecurseMaxDepth); err != nil {
+	if err := g.search(ctx, userGroupsMap, userName, g.config.GroupsRecurseMaxDepth); err != nil {
 		return nil, err
 	}
 
@@ -157,7 +158,7 @@ func (g *GSuiteProvider) search(ctx context.Context, visited map[string]bool, us
 }
 
 // FetchUserInfo fetches additional user information from G Suite using custom schemas.
-func (g *GSuiteProvider) FetchUserInfo(b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) error {
+func (g *GSuiteProvider) FetchUserInfo(ctx context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) error {
 	if !g.config.FetchUserInfo || g.config.UserCustomSchemas == "" {
 		if g.config.UserCustomSchemas != "" {
 			b.Logger().Warn(fmt.Sprintf("must set 'fetch_user_info=true' to fetch 'user_custom_schemas': %s", g.config.UserCustomSchemas))
@@ -171,13 +172,7 @@ func (g *GSuiteProvider) FetchUserInfo(b *jwtAuthBackend, allClaims map[string]i
 		return err
 	}
 
-	// Set context and create a new admin service for requests to Google admin APIs
-	g.adminSvc, err = admin.NewService(b.providerCtx, option.WithHTTPClient(g.jwtConfig.Client(b.providerCtx)))
-	if err != nil {
-		return err
-	}
-
-	return g.fillCustomSchemas(b.providerCtx, userName, allClaims)
+	return g.fillCustomSchemas(ctx, userName, allClaims)
 }
 
 // fillCustomSchemas fetches G Suite user information associated with the custom schemas


### PR DESCRIPTION
## Overview

This PR fixes https://github.com/hashicorp/vault-plugin-auth-jwt/issues/138 by validating the `bound_claims` of a role after the provider-specific group and user info fetching. This allows usage of `bound_claims` for validation against additional group membership and user information on a role. 

## Testing

I've added an automated test which ensures that groups and user info claims can be validated using `bound_claims`.

Additionally, I've manually tested that `bound_claims` validation works against a G Suite account with both groups and user custom schema data.

See test output below with comments explaining the expected results:
```bash
$ vault auth enable oidc
Success! Enabled oidc auth method at: oidc/

$ vault write auth/oidc/config -<<EOF
{
    "oidc_discovery_url": "https://accounts.google.com",
    "oidc_client_id": "redacted",
    "oidc_client_secret": "redacted",
    "default_role": "demo",
    "provider_config": {
        "provider": "gsuite",
        "gsuite_service_account": "/Users/austingebauer/.gcp/gsuite-demo-service-account.json",
        "gsuite_admin_impersonate": "austin@austingebauer.com",
        "fetch_groups": true,
        "fetch_user_info": true,
        "groups_recurse_max_depth": 5,
        "user_custom_schemas": "Education,Preferences"
    }
}
EOF
Success! Data written to: auth/oidc/config

# Note: shirt_size bound claim will cause an expected error when validating claims
$ vault write auth/oidc/role/demo -<<EOF
{
    "allowed_redirect_uris": "http://localhost:8200/ui/vault/auth/oidc/oidc/callback,http://localhost:8250/oidc/callback",
    "claim_mappings": [
        "/Education/graduation_date=graduation_date",
        "/Preferences/shirt_size=shirt_size"
    ],
    "groups_claim": "groups",
    "oidc_scopes": "email",
    "user_claim": "email",
    "bound_claims": {
        "groups": ["g0@austingebauer.com", "g1@austingebauer.com"],
        "/Preferences/shirt_size": "invalid"
    }
}
EOF

$ vault login -method=oidc role=demo
...
* error validating claims: claim "/Preferences/shirt_size" does not match any associated bound claim values

# Note: groups bound claim will cause an expected error when validating claims
$ vault write auth/oidc/role/demo -<<EOF
{
    "allowed_redirect_uris": "http://localhost:8200/ui/vault/auth/oidc/oidc/callback,http://localhost:8250/oidc/callback",
    "claim_mappings": [
        "/Education/graduation_date=graduation_date",
        "/Preferences/shirt_size=shirt_size"
    ],
    "groups_claim": "groups",
    "oidc_scopes": "email",
    "user_claim": "email",
    "bound_claims": {
        "groups": ["invalid@example.com"],
        "/Preferences/shirt_size": "medium"
    }
}
EOF

$ vault login -method=oidc role=demo
...
* error validating claims: claim "groups" does not match any associated bound claim values

# Note: bound claims are valid in this case, so no error is expected
$ vault write auth/oidc/role/demo -<<EOF
{
    "allowed_redirect_uris": "http://localhost:8200/ui/vault/auth/oidc/oidc/callback,http://localhost:8250/oidc/callback",
    "claim_mappings": [
        "/Education/graduation_date=graduation_date",
        "/Preferences/shirt_size=shirt_size"
    ],
    "groups_claim": "groups",
    "oidc_scopes": "email",
    "user_claim": "email",
    "bound_claims": {
        "groups": ["g0@austingebauer.com", "g1@austingebauer.com"],
        "/Preferences/shirt_size": "medium"
    }
}
EOF

$ vault login -method=oidc role=demo
...
Success! You are now authenticated. The token information displayed below
is already stored in the token helper. You do NOT need to run "vault login"
again. Future Vault requests will automatically use this token.
```

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault-plugin-auth-jwt/issues/138
- https://github.com/hashicorp/vault-plugin-auth-jwt/issues/147

## Contributor Checklist
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible