### PR TITLE
Strip signature from debug-logged token

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -251,7 +251,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 			loggedToken = fmt.Sprintf("%s.%s.xxxxxxxxxxx", parts[0], parts[1])
 		}
 
-		b.Logger().Debug("OIDC provider response", "ID token", loggedToken)
+		b.Logger().Debug("OIDC provider response", "id_token", loggedToken)
 	}
 
 	// Parse and verify ID Token payload.

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -243,7 +243,15 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 	}
 
 	if role.VerboseOIDCLogging {
-		b.Logger().Debug("OIDC provider response", "ID token", rawToken)
+		loggedToken := "invalid token format"
+
+		parts := strings.Split(rawToken, ".")
+		if len(parts) == 3 {
+			// strip signature from logged token
+			loggedToken = fmt.Sprintf("%s.%s.xxxxxxxxxxx", parts[0], parts[1])
+		}
+
+		b.Logger().Debug("OIDC provider response", "ID token", loggedToken)
 	}
 
 	// Parse and verify ID Token payload.


### PR DESCRIPTION
The intent of this debug logging is to help understand the structure of the received token. The signature isn't needed for this so let's log the minimum required information.