### PR TITLE
Capture and display OIDC authentication error responses

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -124,6 +124,12 @@ func callbackHandler(c *api.Client, mount string, clientNonce string, doneCh cha
 			doneCh <- loginResp{secret, err}
 		}()
 
+		if req.FormValue("error") != "" || req.FormValue("error_description") != "" {
+			err = fmt.Errorf("Authentication Error Response: %s %s", req.FormValue("error"), req.FormValue("error_description"))
+			response = errorHTML(req.FormValue("error"), req.FormValue("error_description"))
+			return
+		}
+
 		// Pull any parameters from either the body or query parameters.
 		// FormValue prioritizes body values, if found.
 		data := map[string][]string{


### PR DESCRIPTION
# Overview

During OIDC authentication, if the end-user authentication fails, the Authentication Error Response is not presented to the user in the callback handler's rendered error page and the user receives an ambiguous authentication error. e.g. `* Vault login failed. No code or id_token received.`

This change allows the capturing of authentication errors as specified in https://tools.ietf.org/html/rfc6749#section-4.1.2.1

The 'error' and 'error_description' query parameters are used in both the`errorHTML` function respective to the summary and detail arguments and the `callbackHandler`'s `loginResponse` error.

This PR does not change how a user configures or uses the plugin, it's purely an experience improvement.
