### PR TITLE
Adds max_age role parameter and auth_time claim validation

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -439,6 +439,10 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 		options = append(options, oidc.WithImplicitFlow())
 	}
 
+	if role.MaxAge > 0 {
+		options = append(options, oidc.WithMaxAge(uint(role.MaxAge.Seconds())))
+	}
+
 	request, err := oidc.NewRequest(oidcRequestTimeout, redirectURI, options...)
 	if err != nil {
 		return nil, err

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -385,56 +385,46 @@ func TestOIDC_AuthURL_max_age(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, resp.IsError())
 
-	tests := []struct {
-		name           string
+	tests := map[string]struct {
 		maxAge         string
 		expectedMaxAge string
 		expectErr      bool
 	}{
-		{
-			name:           "auth URL for role with integer max_age of 60",
+		"auth URL for role with integer max_age of 60": {
 			maxAge:         "60",
 			expectedMaxAge: "60",
 		},
-		{
-			name:           "auth URL for role with integer max_age of 180",
+		"auth URL for role with integer max_age of 180": {
 			maxAge:         "180",
 			expectedMaxAge: "180",
 		},
-		{
-			name:           "auth URL for role with empty max_age",
+		"auth URL for role with empty max_age": {
 			maxAge:         "",
 			expectedMaxAge: "",
 		},
-		{
-			name:           "auth URL for role with duration string max_age of 30s",
+		"auth URL for role with duration string max_age of 30s": {
 			maxAge:         "30s",
 			expectedMaxAge: "30",
 		},
-		{
-			name:           "auth URL for role with duration string max_age of 2m",
+		"auth URL for role with duration string max_age of 2m": {
 			maxAge:         "2m",
 			expectedMaxAge: "120",
 		},
-		{
-			name:           "auth URL for role with duration string max_age of 1hr",
+		"auth URL for role with duration string max_age of 1hr": {
 			maxAge:         "1h",
 			expectedMaxAge: "3600",
 		},
-		{
-			name:      "auth URL for role with invalid duration string",
+		"auth URL for role with invalid duration string": {
 			maxAge:    "1hr",
 			expectErr: true,
 		},
-		{
-			name:      "auth URL for role with invalid signed integer",
+		"auth URL for role with invalid signed integer": {
 			maxAge:    "-1",
 			expectErr: true,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			// Write the role with the given max age
 			req = &logical.Request{
 				Operation: logical.CreateOperation,

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/cap/oidc"
 	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -361,6 +363,111 @@ func TestOIDC_AuthURL_namespace(t *testing.T) {
 				t.Fatalf("expected state to match regex: %s, %s", test.expectedStateRegEx, state)
 			}
 
+		})
+	}
+}
+
+func TestOIDC_AuthURL_max_age(t *testing.T) {
+	b, storage := getBackend(t)
+
+	// Configure the backend
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"oidc_discovery_url": "https://team-vault.auth0.com/",
+			"oidc_client_id":     "abc",
+			"oidc_client_secret": "def",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	tests := []struct {
+		name           string
+		maxAge         string
+		expectedMaxAge string
+		expectErr      bool
+	}{
+		{
+			name:           "auth URL for role with integer max_age of 60",
+			maxAge:         "60",
+			expectedMaxAge: "60",
+		},
+		{
+			name:           "auth URL for role with integer max_age of 180",
+			maxAge:         "180",
+			expectedMaxAge: "180",
+		},
+		{
+			name:           "auth URL for role with empty max_age",
+			maxAge:         "",
+			expectedMaxAge: "",
+		},
+		{
+			name:           "auth URL for role with duration string max_age of 30s",
+			maxAge:         "30s",
+			expectedMaxAge: "30",
+		},
+		{
+			name:           "auth URL for role with duration string max_age of 2m",
+			maxAge:         "2m",
+			expectedMaxAge: "120",
+		},
+		{
+			name:           "auth URL for role with duration string max_age of 1hr",
+			maxAge:         "1h",
+			expectedMaxAge: "3600",
+		},
+		{
+			name:      "auth URL for role with invalid duration string",
+			maxAge:    "1hr",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write the role with the given max age
+			req = &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      "role/test",
+				Storage:   storage,
+				Data: map[string]interface{}{
+					"user_claim":            "email",
+					"allowed_redirect_uris": []string{"https://example.com"},
+					"max_age":               tt.maxAge,
+				},
+			}
+			resp, err = b.HandleRequest(context.Background(), req)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.False(t, resp.IsError())
+
+			// Request for generation of an auth URL
+			req = &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      "oidc/auth_url",
+				Storage:   storage,
+				Data: map[string]interface{}{
+					"role":         "test",
+					"redirect_uri": "https://example.com",
+				},
+			}
+			resp, err = b.HandleRequest(context.Background(), req)
+			require.NoError(t, err)
+			require.False(t, resp.IsError())
+
+			// Parse the auth URL and assert the expected max_age query parameter
+			parsedAuthURL, err := url.Parse(resp.Data["auth_url"].(string))
+			require.NoError(t, err)
+			queryParams := parsedAuthURL.Query()
+			assert.Equal(t, tt.expectedMaxAge, queryParams.Get("max_age"))
 		})
 	}
 }

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -426,6 +426,11 @@ func TestOIDC_AuthURL_max_age(t *testing.T) {
 			maxAge:    "1hr",
 			expectErr: true,
 		},
+		{
+			name:      "auth URL for role with invalid signed integer",
+			maxAge:    "-1",
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/path_role.go
+++ b/path_role.go
@@ -143,6 +143,11 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 Not recommended in production since sensitive information may be present 
 in OIDC responses.`,
 			},
+			"max_age": {
+				Type: framework.TypeDurationSecond,
+				Description: `Specifies the allowable elapsed time in seconds since the last time the 
+user was actively authenticated.`,
+			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -201,6 +206,7 @@ type jwtRole struct {
 	OIDCScopes          []string               `json:"oidc_scopes"`
 	AllowedRedirectURIs []string               `json:"allowed_redirect_uris"`
 	VerboseOIDCLogging  bool                   `json:"verbose_oidc_logging"`
+	MaxAge              time.Duration          `json:"max_age"`
 
 	// Deprecated by TokenParams
 	Policies   []string                      `json:"policies"`
@@ -307,6 +313,7 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 		"allowed_redirect_uris": role.AllowedRedirectURIs,
 		"oidc_scopes":           role.OIDCScopes,
 		"verbose_oidc_logging":  role.VerboseOIDCLogging,
+		"max_age":               int64(role.MaxAge.Seconds()),
 	}
 
 	role.PopulateTokenData(d)
@@ -438,6 +445,10 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 
 	if verboseOIDCLoggingRaw, ok := data.GetOk("verbose_oidc_logging"); ok {
 		role.VerboseOIDCLogging = verboseOIDCLoggingRaw.(bool)
+	}
+
+	if maxAgeRaw, ok := data.GetOk("max_age"); ok {
+		role.MaxAge = time.Duration(maxAgeRaw.(int)) * time.Second
 	}
 
 	boundClaimsType := data.Get("bound_claims_type").(string)

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -53,6 +53,7 @@ func TestPath_Create(t *testing.T) {
 			"ttl":             "1s",
 			"num_uses":        12,
 			"max_ttl":         "5s",
+			"max_age":         "60s",
 		}
 
 		expectedSockAddr, err := sockaddr.NewSockAddr("127.0.0.1/8")
@@ -85,6 +86,7 @@ func TestPath_Create(t *testing.T) {
 			NumUses:             12,
 			BoundCIDRs:          []*sockaddr.SockAddrMarshaler{{SockAddr: expectedSockAddr}},
 			AllowedRedirectURIs: []string(nil),
+			MaxAge:              60 * time.Second,
 		}
 
 		req := &logical.Request{
@@ -783,6 +785,7 @@ func TestPath_Read(t *testing.T) {
 		"token_type":              logical.TokenTypeDefault.String(),
 		"token_no_default_policy": false,
 		"token_explicit_max_ttl":  int64(0),
+		"max_age":                 int64(0),
 	}
 
 	req := &logical.Request{


### PR DESCRIPTION
## Overview

This PR adds a new `max_age` parameter to roles. The `max_age` specifies the allowable elapsed time in seconds since the last time the user actively authenticated with the configured identity provider. 

When `max_age` is used, the ID Token returned must include an `auth_time` claim value (see [openid-connect-core-1_0.html#AuthRequest](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)). Validation of the `auth_time` claim value is provided by the cap/oidc library (see [oidc/provider.go#L414](https://github.com/hashicorp/cap/blob/main/oidc/provider.go#L414)).

The `max_age` for a role will be included in the generated auth URL as a query parameter, similar to the following example:

```
https://example.auth0.com/authorize?client_id=abc&max_age=60&nonce=n_NEJOgEMl4MBXf0LX6ES4&redirect_uri=https%3A%2F%2Fexample.com&response_type=code&scope=openid&state=st_o1myOrU9vQi6uiiR6SpU
```

## Testing

I've added a test for setting the `max_age` role parameter and generating an auth URL with the `max_age` query parameter.

I've also manually tested Azure Active Directory authentication using `max_age` to observe that active authentication was forced depending on the `max_age` and time of last active authentication.