### PR TITLE
Include role name in Entity Alias metadata

### DIFF
--- a/path_login_test.go
+++ b/path_login_test.go
@@ -409,6 +409,7 @@ func testLogin_JWT(t *testing.T, jwks bool) {
 			metadata := map[string]string{
 				"name":        "jeff2",
 				"primary_org": "engineering",
+				"role":        "plugin-test",
 			}
 
 			if diff := deep.Equal(auth.Alias.Metadata, metadata); diff != nil {
@@ -416,7 +417,6 @@ func testLogin_JWT(t *testing.T, jwks bool) {
 			}
 
 			// check token metadata
-			metadata["role"] = "plugin-test"
 			if diff := deep.Equal(auth.Metadata, metadata); diff != nil {
 				t.Fatal(diff)
 			}

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -318,7 +318,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		}
 	}
 
-	alias, groupAliases, err := b.createIdentity(ctx, allClaims, role, tokenSource)
+	alias, groupAliases, err := b.createIdentity(ctx, allClaims, roleName, role, tokenSource)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -327,7 +327,7 @@ func (b *jwtAuthBackend) pathCallback(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse("error validating claims: %s", err.Error()), nil
 	}
 
-	tokenMetadata := map[string]string{"role": roleName}
+	tokenMetadata := make(map[string]string)
 	for k, v := range alias.Metadata {
 		tokenMetadata[k] = v
 	}

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -790,6 +790,7 @@ func TestOIDC_Callback(t *testing.T) {
 				Alias: &logical.Alias{
 					Name: "bob@example.com",
 					Metadata: map[string]string{
+						"role":  "test",
 						"color": "green",
 						"size":  "medium",
 					},


### PR DESCRIPTION
# Overview
This PR is suggesting the addition of the `role` name in the Entity Alias metadata on successful login.

**Adding the role name on the Entity Alias metadata makes it easier to manage access to endpoints via [ACL templated policies](https://learn.hashicorp.com/tutorials/vault/policy-templating#step-1-write-templated-acl-policies). Using the plugin mount accessor, one can simply use the following rule to restrict access: `identity.entity.aliases.<mount_accessor>.metadata.role`**. Another auth plugin, AppRole, recently implemented this change for the same reason: https://github.com/hashicorp/vault/pull/9529

Also, it already seems like the authors of _this_ plugin had in mind that `role` is an important metadata that should not be overriden. We can assume this from the following two things. First, the only way to set metadata attributes on the Entity is through the [`claim_mappings`](https://www.vaultproject.io/api/auth/jwt#claim_mappings) property when creating an OIDC role (`claim_mappings` is the only way where properties from the OIDC JWT token will be mapped directly into the Entity Alias metadata). Second, we can see from the code that there is [special reserved metadata *role*](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/main/path_role.go#L21), which cannot be included in the `claim_mappings`: https://github.com/hashicorp/vault-plugin-auth-jwt/blob/main/path_role.go#L508. I can think only of 2 reasons why that is the case - 1) `role` is important to be present on the metadata without being overridden; 2) `role` must never appear in the metadata and should be excluded. 

My assumption is that the developers of this plugin had option 1 in mind. However, as of now, the `role` metadata is not present on the Entity Alias metadata and cannot be included. Therefore, I am suggesting this PR to add `role` in the Entity Alias metadata.

# Design of Change
The `role` name is added directly on the Entity Alias metadata on a successful login in the 2 available flows:
- the OIDC flow with a browser redirect
- the JWT flow

# Related Issues/Pull Requests
None

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[X] Backwards compatible
