### PR TITLE
Validate JWT supported algorithms against supported set if not provided in config

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -92,12 +92,21 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return logical.ErrorResponse("error configuring token validator: %s", err.Error()), nil
 	}
 
+	// Validate JWT supported algorithms if they've been provided. Otherwise,
+	// ensure that the signing algorithm is a member of the supported set.
+	signingAlgorithms := toAlg(config.JWTSupportedAlgs)
+	if len(signingAlgorithms) == 0 {
+		signingAlgorithms = []jwt.Alg{
+			jwt.RS256, jwt.RS384, jwt.RS512, jwt.ES256, jwt.ES384,
+			jwt.ES512, jwt.PS256, jwt.PS384, jwt.PS512, jwt.EdDSA}
+	}
+
 	// Set expected claims values to assert on the JWT
 	expected := jwt.Expected{
 		Issuer:            config.BoundIssuer,
 		Subject:           role.BoundSubject,
 		Audiences:         role.BoundAudiences,
-		SigningAlgorithms: toAlg(config.JWTSupportedAlgs),
+		SigningAlgorithms: signingAlgorithms,
 		NotBeforeLeeway:   role.NotBeforeLeeway,
 		ExpirationLeeway:  role.ExpirationLeeway,
 		ClockSkewLeeway:   role.ClockSkewLeeway,

--- a/path_login.go
+++ b/path_login.go
@@ -98,7 +98,8 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 	if len(signingAlgorithms) == 0 {
 		signingAlgorithms = []jwt.Alg{
 			jwt.RS256, jwt.RS384, jwt.RS512, jwt.ES256, jwt.ES384,
-			jwt.ES512, jwt.PS256, jwt.PS384, jwt.PS512, jwt.EdDSA}
+			jwt.ES512, jwt.PS256, jwt.PS384, jwt.PS512, jwt.EdDSA,
+		}
 	}
 
 	// Set expected claims values to assert on the JWT


### PR DESCRIPTION
## Overview

This PR changes the handling of `jwt_supported_algs` to be consistent with the behavior prior to PR https://github.com/hashicorp/vault-plugin-auth-jwt/pull/155. This means that `jwt_supported_algs` will remain optional and default to the set of algorithms defined in [jwt/algs.go#L12-L21](https://github.com/hashicorp/cap/blob/main/jwt/algs.go#L12-L21) for JWT based authentication.

A default of `RS256` is still used for OIDC based authentication.

## Testing

I've tested that JWT auth works without needing to always provide the correct signing algorithm via `jwt_supported_algs` for both JWKS and static key configurations.