### PR TITLE
Adds ability to directly provide service account JSON in G Suite provider config

### DIFF
--- a/provider_gsuite.go
+++ b/provider_gsuite.go
@@ -6,26 +6,28 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"golang.org/x/oauth2/jwt"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
 )
 
 // GSuiteProvider provides G Suite-specific configuration and behavior.
 type GSuiteProvider struct {
-	config    GSuiteProviderConfig // Configuration for the provider
-	jwtConfig *jwt.Config          // Google JWT configuration
-	adminSvc  *admin.Service       // Google admin service
+	// Configuration for the provider
+	config GSuiteProviderConfig
+
+	// Google admin service
+	adminSvc *admin.Service
 }
 
 // GSuiteProviderConfig represents the configuration for a GSuiteProvider.
 type GSuiteProviderConfig struct {
-	// Path to a Google service account key file. Required.
-	ServiceAccountFilePath string `mapstructure:"gsuite_service_account"`
+	// The path to or contents of a Google service account key file. Required.
+	ServiceAccount string `mapstructure:"gsuite_service_account"`
 
 	// Email address of a G Suite admin to impersonate. Required.
 	AdminImpersonateEmail string `mapstructure:"gsuite_admin_impersonate"`
@@ -41,9 +43,6 @@ type GSuiteProviderConfig struct {
 
 	// Comma-separated list of G Suite custom schemas to fetch as claims.
 	UserCustomSchemas string `mapstructure:"user_custom_schemas"`
-
-	// JSON contents of a Google service account key file.
-	serviceAccountKeyJSON []byte
 }
 
 // Initialize initializes the GSuiteProvider by validating and creating configuration.
@@ -54,23 +53,10 @@ func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 		return err
 	}
 
-	// Read the Google service account key file
-	keyJSON, err := ioutil.ReadFile(config.ServiceAccountFilePath)
-	if err != nil {
-		return err
-	}
-	config.serviceAccountKeyJSON = keyJSON
-
-	return g.initialize(ctx, config)
-}
-
-func (g *GSuiteProvider) initialize(ctx context.Context, config GSuiteProviderConfig) error {
-	var err error
-
 	// Validate configuration
-	if config.ServiceAccountFilePath == "" {
-		return errors.New("'gsuite_service_account' must be set to the file path for a " +
-			"service account key")
+	if config.ServiceAccount == "" {
+		return errors.New("'gsuite_service_account' must be either the path to or contents of " +
+			"a JSON service account key file")
 	}
 	if config.AdminImpersonateEmail == "" {
 		return errors.New("'gsuite_admin_impersonate' must be set to an email address of a " +
@@ -80,28 +66,47 @@ func (g *GSuiteProvider) initialize(ctx context.Context, config GSuiteProviderCo
 		return errors.New("'gsuite_recurse_max_depth' must be a positive integer")
 	}
 
-	// Create the google JWT config from the service account key file
-	if g.jwtConfig, err = google.JWTConfigFromJSON(config.serviceAccountKeyJSON,
-		admin.AdminDirectoryGroupReadonlyScope, admin.AdminDirectoryUserReadonlyScope); err != nil {
-		return err
+	// A file path or JSON string may be provided for the service account parameter.
+	// Check to see if a file exists at the given path, and if so, read its contents.
+	// Otherwise, assume the service account has been provided as a JSON string.
+	var err error
+	keyJSON := []byte(config.ServiceAccount)
+	if fileExists(config.ServiceAccount) {
+		keyJSON, err = ioutil.ReadFile(config.ServiceAccount)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Set the subject to impersonate and config
-	g.jwtConfig.Subject = config.AdminImpersonateEmail
-	g.config = config
+	// Set the requested scopes
+	scopes := []string{
+		admin.AdminDirectoryGroupReadonlyScope,
+		admin.AdminDirectoryUserReadonlyScope,
+	}
+
+	// Create the google JWT config from the service account
+	jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+	if err != nil {
+		return fmt.Errorf("error parsing service account JSON: %w", err)
+	}
+
+	// Set the subject to impersonate
+	jwtConfig.Subject = config.AdminImpersonateEmail
 
 	// Create a new admin service for requests to Google admin APIs
-	g.adminSvc, err = admin.NewService(ctx, option.WithHTTPClient(g.jwtConfig.Client(ctx)))
+	svc, err := admin.NewService(ctx, option.WithHTTPClient(jwtConfig.Client(ctx)))
 	if err != nil {
 		return err
 	}
 
+	g.adminSvc = svc
+	g.config = config
 	return nil
 }
 
 // SensitiveKeys returns keys that should be redacted when reading the config of this provider
 func (g *GSuiteProvider) SensitiveKeys() []string {
-	return []string{}
+	return []string{"gsuite_service_account"}
 }
 
 // FetchGroups fetches and returns groups from G Suite.
@@ -213,4 +218,10 @@ func (g *GSuiteProvider) getUserClaim(b *jwtAuthBackend, allClaims map[string]in
 	}
 
 	return userClaim, nil
+}
+
+// fileExists returns true if a file exists at the given path.
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi != nil && !fi.IsDir()
 }

--- a/provider_gsuite_test.go
+++ b/provider_gsuite_test.go
@@ -233,7 +233,7 @@ func TestGSuiteProvider_search(t *testing.T) {
 
 	type args struct {
 		user   string
-		config GSuiteProviderConfig
+		config *jwtConfig
 	}
 	tests := []struct {
 		name     string
@@ -244,11 +244,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user that's in no groups",
 			args: args{
 				user: "noGroupUser",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{},
@@ -257,11 +258,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group that's in no groups",
 			args: args{
 				user: "group3@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{},
@@ -270,11 +272,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with default recursion max depth 0",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{
@@ -285,12 +288,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with recursion max depth 1",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  1,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 1,
+					},
 				},
 			},
 			expected: []string{
@@ -302,12 +306,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with recursion max depth 10",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  10,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 10,
+					},
 				},
 			},
 			expected: []string{
@@ -320,11 +325,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with default recursion max depth 0",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{
@@ -335,12 +341,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with recursion max depth 1",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  1,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 1,
+					},
 				},
 			},
 			expected: []string{
@@ -352,12 +359,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with recursion max depth 10",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  10,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 10,
+					},
 				},
 			},
 			expected: []string{
@@ -373,7 +381,7 @@ func TestGSuiteProvider_search(t *testing.T) {
 
 			// Initialize the provider
 			gProvider := new(GSuiteProvider)
-			assert.NoError(t, gProvider.initialize(ctx, tt.args.config))
+			assert.NoError(t, gProvider.Initialize(ctx, tt.args.config))
 
 			// Fetch groups from the groupsServer
 			gProvider.adminSvc, _ = admin.NewService(ctx, option.WithHTTPClient(&http.Client{}))
@@ -391,9 +399,9 @@ func TestGSuiteProvider_search(t *testing.T) {
 	}
 }
 
-func TestGSuiteProvider_initialize(t *testing.T) {
+func TestGSuiteProvider_Initialize(t *testing.T) {
 	type args struct {
-		config GSuiteProviderConfig
+		config *jwtConfig
 	}
 	tests := []struct {
 		name    string
@@ -403,11 +411,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: required service account key is empty",
 			args: args{
-				config: GSuiteProviderConfig{
-					AdminImpersonateEmail: "test@example.com",
-					GroupsRecurseMaxDepth: -1,
-					UserCustomSchemas:     "Custom",
-					serviceAccountKeyJSON: []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -415,11 +424,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: required admin impersonate email is empty",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					GroupsRecurseMaxDepth:  -1,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -427,12 +437,13 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: recurse max depth negative number",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  -1,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -440,12 +451,13 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: all options",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  5,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": 5,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: false,
@@ -453,11 +465,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: no custom schemas",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  5,
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": 5,
+					},
 				},
 			},
 			wantErr: false,
@@ -465,11 +478,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: no recurse max depth",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					UserCustomSchemas:      "Custom",
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: false,
@@ -477,13 +491,14 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: fetch groups and user info",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					UserCustomSchemas:      "Custom",
-					FetchGroups:            true,
-					FetchUserInfo:          true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"user_custom_schemas":      "Custom",
+						"fetch_groups":             true,
+						"fetch_user_info":          true,
+					},
 				},
 			},
 			wantErr: false,
@@ -492,11 +507,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &GSuiteProvider{}
+			err := g.Initialize(context.Background(), tt.args.config)
 			if tt.wantErr {
-				assert.Error(t, g.initialize(context.Background(), tt.args.config))
-			} else {
-				assert.NoError(t, g.initialize(context.Background(), tt.args.config))
+				assert.Error(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -549,17 +565,18 @@ func TestGSuiteProvider_validateBoundClaims(t *testing.T) {
 	}
 
 	// Configure the provider
-	config := GSuiteProviderConfig{
-		ServiceAccountFilePath: "/path/to/google-service-account.json",
-		AdminImpersonateEmail:  "admin@example.com",
-		FetchGroups:            true,
-		FetchUserInfo:          true,
-		GroupsRecurseMaxDepth:  5,
-		UserCustomSchemas:      "Preferences",
-		serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+	config := &jwtConfig{
+		ProviderConfig: map[string]interface{}{
+			"gsuite_service_account":   `{"type": "service_account"}`,
+			"gsuite_admin_impersonate": "admin@example.com",
+			"fetch_groups":             true,
+			"fetch_user_info":          true,
+			"groups_recurse_max_depth": 5,
+			"user_custom_schemas":      "Preferences",
+		},
 	}
 	provider := &GSuiteProvider{}
-	err := provider.initialize(ctx, config)
+	err := provider.Initialize(ctx, config)
 	assert.NoError(t, err)
 
 	// Swap the base URL to make requests to gServer


### PR DESCRIPTION
## Overview

This PR enables the [gsuite_service_account](https://www.vaultproject.io/docs/auth/jwt_oidc_providers#gsuite_service_account) to be directly provided as a JSON string in the G Suite provider config. This is similar to how credentials are provided in the GCP [secrets](https://www.vaultproject.io/api-docs/secret/gcp#credentials) and [auth](https://www.vaultproject.io/api-docs/auth/gcp#credentials) plugins. To remain backward compatible, the credentials may still be provided as a path to a service account file on the host that the plugin is running on.

This PR also implements the [SensitiveKeys](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/provider_config.go#L29-L31) behavior for custom providers. This is used to omit sensitive configuration (e.g., raw service account credentials) when reading from the [configure](https://www.vaultproject.io/api-docs/auth/jwt#configure) API.

## Additional Context

I originally intended to address https://github.com/hashicorp/vault-plugin-auth-jwt/issues/139 by also supporting Application Default Credentials (ADC). There are a couple of things preventing that from happening. First, the [impersonate package](https://pkg.go.dev/google.golang.org/api@v0.44.0-impersonate-preview/impersonate) that supports [domain-wide delegation of authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation) using ADC is currently marked as preview/experimental. Second, there is a dependency issue between etcd/grpc that occurs in Vault when updating [google-api-go-client](https://github.com/googleapis/google-api-go-client) to the latest version. For now, I'm simply adding an additional way to provide the service account in order to allow the feature to work in environments where there is no host access (e.g., HCP Vault).

The UX for directly providing the service account is less than ideal because the [provider_config](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/path_config.go#L86) parameter is `TypeMap`. This forces the plugin config to be provided as JSON to the Vault CLI (see examples below). The service account credentials are also JSON, so we're providing JSON in JSON. This means that all double quotes `"` need to be escaped when directly providing the service account. I'm open to suggestions for improving this UX.

## Testing

I ran successfully ran acceptance tests and manual tests using both configuration options. Examples of each configuration option are provided below.

### Service Account JSON

The contents of `/path/to/service-account.json` must be properly escaped. I used `jq -R` to do so.

```
vault write auth/gsuite-oidc/config -<<EOF
{
    "oidc_discovery_url": "https://accounts.google.com",
    "oidc_client_id": "*****-uaevvp8s8m7j1208vf347u4a6mtkhraj.apps.googleusercontent.com",
    "oidc_client_secret": "*****",
    "provider_config": {
        "provider": "gsuite",
        "gsuite_service_account": $(cat /path/to/service-account.json),
        "gsuite_admin_impersonate": "austin@austingebauer.com",
        "fetch_groups": true,
        "fetch_user_info": true,
        "groups_recurse_max_depth": 5,
        "user_custom_schemas": "Education,Preferences"
    }
}
EOF
```

### File Path to Service Account

This was the existing behavior. It is unchanged by this PR.
```
vault write auth/gsuite-oidc/config -<<EOF
{
    "oidc_discovery_url": "https://accounts.google.com",
    "oidc_client_id": "*****-uaevvp8s8m7j1208vf347u4a6mtkhraj.apps.googleusercontent.com",
    "oidc_client_secret": "*****",
    "provider_config": {
        "provider": "gsuite",
        "gsuite_service_account": "/path/to/service-account.json",
        "gsuite_admin_impersonate": "austin@austingebauer.com",
        "fetch_groups": true,
        "fetch_user_info": true,
        "groups_recurse_max_depth": 5,
        "user_custom_schemas": "Education,Preferences"
    }
}
EOF
```

## Related Issues/Pull Requests

- https://github.com/hashicorp/vault-plugin-auth-jwt/issues/139
