### PR TITLE
Backport 1.7.x: Adds ability to directly provide service account JSON in G Suite provider config (#167)

### DIFF
--- a/provider_gsuite.go
+++ b/provider_gsuite.go
@@ -6,26 +6,28 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"golang.org/x/oauth2/jwt"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
 )
 
 // GSuiteProvider provides G Suite-specific configuration and behavior.
 type GSuiteProvider struct {
-	config    GSuiteProviderConfig // Configuration for the provider
-	jwtConfig *jwt.Config          // Google JWT configuration
-	adminSvc  *admin.Service       // Google admin service
+	// Configuration for the provider
+	config GSuiteProviderConfig
+
+	// Google admin service
+	adminSvc *admin.Service
 }
 
 // GSuiteProviderConfig represents the configuration for a GSuiteProvider.
 type GSuiteProviderConfig struct {
-	// Path to a Google service account key file. Required.
-	ServiceAccountFilePath string `mapstructure:"gsuite_service_account"`
+	// The path to or contents of a Google service account key file. Required.
+	ServiceAccount string `mapstructure:"gsuite_service_account"`
 
 	// Email address of a G Suite admin to impersonate. Required.
 	AdminImpersonateEmail string `mapstructure:"gsuite_admin_impersonate"`
@@ -41,9 +43,6 @@ type GSuiteProviderConfig struct {
 
 	// Comma-separated list of G Suite custom schemas to fetch as claims.
 	UserCustomSchemas string `mapstructure:"user_custom_schemas"`
-
-	// JSON contents of a Google service account key file.
-	serviceAccountKeyJSON []byte
 }
 
 // Initialize initializes the GSuiteProvider by validating and creating configuration.
@@ -54,23 +53,10 @@ func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 		return err
 	}
 
-	// Read the Google service account key file
-	keyJSON, err := ioutil.ReadFile(config.ServiceAccountFilePath)
-	if err != nil {
-		return err
-	}
-	config.serviceAccountKeyJSON = keyJSON
-
-	return g.initialize(ctx, config)
-}
-
-func (g *GSuiteProvider) initialize(ctx context.Context, config GSuiteProviderConfig) error {
-	var err error
-
 	// Validate configuration
-	if config.ServiceAccountFilePath == "" {
-		return errors.New("'gsuite_service_account' must be set to the file path for a " +
-			"service account key")
+	if config.ServiceAccount == "" {
+		return errors.New("'gsuite_service_account' must be either the path to or contents of " +
+			"a JSON service account key file")
 	}
 	if config.AdminImpersonateEmail == "" {
 		return errors.New("'gsuite_admin_impersonate' must be set to an email address of a " +
@@ -80,28 +66,47 @@ func (g *GSuiteProvider) initialize(ctx context.Context, config GSuiteProviderCo
 		return errors.New("'gsuite_recurse_max_depth' must be a positive integer")
 	}
 
-	// Create the google JWT config from the service account key file
-	if g.jwtConfig, err = google.JWTConfigFromJSON(config.serviceAccountKeyJSON,
-		admin.AdminDirectoryGroupReadonlyScope, admin.AdminDirectoryUserReadonlyScope); err != nil {
-		return err
+	// A file path or JSON string may be provided for the service account parameter.
+	// Check to see if a file exists at the given path, and if so, read its contents.
+	// Otherwise, assume the service account has been provided as a JSON string.
+	var err error
+	keyJSON := []byte(config.ServiceAccount)
+	if fileExists(config.ServiceAccount) {
+		keyJSON, err = ioutil.ReadFile(config.ServiceAccount)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Set the subject to impersonate and config
-	g.jwtConfig.Subject = config.AdminImpersonateEmail
-	g.config = config
+	// Set the requested scopes
+	scopes := []string{
+		admin.AdminDirectoryGroupReadonlyScope,
+		admin.AdminDirectoryUserReadonlyScope,
+	}
+
+	// Create the google JWT config from the service account
+	jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+	if err != nil {
+		return fmt.Errorf("error parsing service account JSON: %w", err)
+	}
+
+	// Set the subject to impersonate
+	jwtConfig.Subject = config.AdminImpersonateEmail
 
 	// Create a new admin service for requests to Google admin APIs
-	g.adminSvc, err = admin.NewService(ctx, option.WithHTTPClient(g.jwtConfig.Client(ctx)))
+	svc, err := admin.NewService(ctx, option.WithHTTPClient(jwtConfig.Client(ctx)))
 	if err != nil {
 		return err
 	}
 
+	g.adminSvc = svc
+	g.config = config
 	return nil
 }
 
 // SensitiveKeys returns keys that should be redacted when reading the config of this provider
 func (g *GSuiteProvider) SensitiveKeys() []string {
-	return []string{}
+	return []string{"gsuite_service_account"}
 }
 
 // FetchGroups fetches and returns groups from G Suite.
@@ -213,4 +218,10 @@ func (g *GSuiteProvider) getUserClaim(b *jwtAuthBackend, allClaims map[string]in
 	}
 
 	return userClaim, nil
+}
+
+// fileExists returns true if a file exists at the given path.
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi != nil && !fi.IsDir()
 }

--- a/provider_gsuite_test.go
+++ b/provider_gsuite_test.go
@@ -233,7 +233,7 @@ func TestGSuiteProvider_search(t *testing.T) {
 
 	type args struct {
 		user   string
-		config GSuiteProviderConfig
+		config *jwtConfig
 	}
 	tests := []struct {
 		name     string
@@ -244,11 +244,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user that's in no groups",
 			args: args{
 				user: "noGroupUser",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{},
@@ -257,11 +258,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group that's in no groups",
 			args: args{
 				user: "group3@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{},
@@ -270,11 +272,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with default recursion max depth 0",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{
@@ -285,12 +288,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with recursion max depth 1",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  1,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 1,
+					},
 				},
 			},
 			expected: []string{
@@ -302,12 +306,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for user with recursion max depth 10",
 			args: args{
 				user: "user1",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  10,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 10,
+					},
 				},
 			},
 			expected: []string{
@@ -320,11 +325,12 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with default recursion max depth 0",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+					},
 				},
 			},
 			expected: []string{
@@ -335,12 +341,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with recursion max depth 1",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  1,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 1,
+					},
 				},
 			},
 			expected: []string{
@@ -352,12 +359,13 @@ func TestGSuiteProvider_search(t *testing.T) {
 			name: "fetch groups for group with recursion max depth 10",
 			args: args{
 				user: "group1@group.com",
-				config: GSuiteProviderConfig{
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					FetchGroups:            true,
-					GroupsRecurseMaxDepth:  10,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"fetch_groups":             true,
+						"groups_recurse_max_depth": 10,
+					},
 				},
 			},
 			expected: []string{
@@ -373,7 +381,7 @@ func TestGSuiteProvider_search(t *testing.T) {
 
 			// Initialize the provider
 			gProvider := new(GSuiteProvider)
-			assert.NoError(t, gProvider.initialize(ctx, tt.args.config))
+			assert.NoError(t, gProvider.Initialize(ctx, tt.args.config))
 
 			// Fetch groups from the groupsServer
 			gProvider.adminSvc, _ = admin.NewService(ctx, option.WithHTTPClient(&http.Client{}))
@@ -391,9 +399,9 @@ func TestGSuiteProvider_search(t *testing.T) {
 	}
 }
 
-func TestGSuiteProvider_initialize(t *testing.T) {
+func TestGSuiteProvider_Initialize(t *testing.T) {
 	type args struct {
-		config GSuiteProviderConfig
+		config *jwtConfig
 	}
 	tests := []struct {
 		name    string
@@ -403,11 +411,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: required service account key is empty",
 			args: args{
-				config: GSuiteProviderConfig{
-					AdminImpersonateEmail: "test@example.com",
-					GroupsRecurseMaxDepth: -1,
-					UserCustomSchemas:     "Custom",
-					serviceAccountKeyJSON: []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -415,11 +424,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: required admin impersonate email is empty",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					GroupsRecurseMaxDepth:  -1,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -427,12 +437,13 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "invalid config: recurse max depth negative number",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  -1,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": -1,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: true,
@@ -440,12 +451,13 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: all options",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  5,
-					UserCustomSchemas:      "Custom",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": 5,
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: false,
@@ -453,11 +465,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: no custom schemas",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					GroupsRecurseMaxDepth:  5,
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"groups_recurse_max_depth": 5,
+					},
 				},
 			},
 			wantErr: false,
@@ -465,11 +478,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: no recurse max depth",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					UserCustomSchemas:      "Custom",
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"user_custom_schemas":      "Custom",
+					},
 				},
 			},
 			wantErr: false,
@@ -477,13 +491,14 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 		{
 			name: "valid config: fetch groups and user info",
 			args: args{
-				config: GSuiteProviderConfig{
-					ServiceAccountFilePath: "/path/to/google-service-account.json",
-					AdminImpersonateEmail:  "test@example.com",
-					serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
-					UserCustomSchemas:      "Custom",
-					FetchGroups:            true,
-					FetchUserInfo:          true,
+				config: &jwtConfig{
+					ProviderConfig: map[string]interface{}{
+						"gsuite_service_account":   `{"type": "service_account"}`,
+						"gsuite_admin_impersonate": "test@example.com",
+						"user_custom_schemas":      "Custom",
+						"fetch_groups":             true,
+						"fetch_user_info":          true,
+					},
 				},
 			},
 			wantErr: false,
@@ -492,11 +507,12 @@ func TestGSuiteProvider_initialize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &GSuiteProvider{}
+			err := g.Initialize(context.Background(), tt.args.config)
 			if tt.wantErr {
-				assert.Error(t, g.initialize(context.Background(), tt.args.config))
-			} else {
-				assert.NoError(t, g.initialize(context.Background(), tt.args.config))
+				assert.Error(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -549,17 +565,18 @@ func TestGSuiteProvider_validateBoundClaims(t *testing.T) {
 	}
 
 	// Configure the provider
-	config := GSuiteProviderConfig{
-		ServiceAccountFilePath: "/path/to/google-service-account.json",
-		AdminImpersonateEmail:  "admin@example.com",
-		FetchGroups:            true,
-		FetchUserInfo:          true,
-		GroupsRecurseMaxDepth:  5,
-		UserCustomSchemas:      "Preferences",
-		serviceAccountKeyJSON:  []byte(`{"type": "service_account"}`),
+	config := &jwtConfig{
+		ProviderConfig: map[string]interface{}{
+			"gsuite_service_account":   `{"type": "service_account"}`,
+			"gsuite_admin_impersonate": "admin@example.com",
+			"fetch_groups":             true,
+			"fetch_user_info":          true,
+			"groups_recurse_max_depth": 5,
+			"user_custom_schemas":      "Preferences",
+		},
 	}
 	provider := &GSuiteProvider{}
-	err := provider.initialize(ctx, config)
+	err := provider.Initialize(ctx, config)
 	assert.NoError(t, err)
 
 	// Swap the base URL to make requests to gServer


### PR DESCRIPTION
This PR backports an enhancement from #167 to the 1.7.x release branch.

The following steps were taken:
1. `git checkout release/vault-1.7.x`
2. `git checkout -b backport-pr-167-1.7.x`
3. `git cherry-pick f8f6db6`