### PR TITLE
Select browser using environment variable

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -205,6 +205,7 @@ func isWSL() bool {
 }
 
 // openURL opens the specified URL in the default browser of the user.
+// If the BROWSER environment variable is set it will be used instead.
 // Source: https://stackoverflow.com/a/39324149/453290
 func openURL(url string) error {
 	var cmd string
@@ -220,6 +221,12 @@ func openURL(url string) error {
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
 	}
+
+	// Allow users to define the browser instead of using the default one
+	if os.Getenv("BROWSER") != "" {
+		cmd = os.Getenv("BROWSER")
+	}
+
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()
 }


### PR DESCRIPTION
# Overview
This change only affects the CLI usage when running `vault login`.
Currently `vault login` always opens the default browser for login via OIDC. However for security reasons there might be the need to use a different browser which is logged in to OIDC as a higher privileged user (you might not want to browse as an admin for regular work..).

This PR adds the option to select a different browser by setting the `BROWSER` environment variable. 
Example: `BROWSER=/usr/bin/firefox vault login -method=oidc`. The default behaviour will stay the same.

# Design of Change
The change is pretty straightforward: If the environment variable is set it will overwrite the cmd that was chosen for opening the default browser.

# Related Issues/Pull Requests
None

# Contributor Checklist
[?] Relevant docs: I'm not sure if docs would need to be updated for this simple change. The `BROWSER` environment variable seems to be more or less a standard. But I'm happy to add some explaination to the docs if wanted :) 
[x] Backwards compatible: The default behaviour stays the same
