### PR TITLE
Fixes form_post response mode scripting for browser

### DIFF
--- a/cli_responses.go
+++ b/cli_responses.go
@@ -449,7 +449,7 @@ func formpostHTML(path, code, state string) string {
       </div>
     </div>
 	<script>
-		window.localStorage.setItem("oidcState", JSON.stringify({"path":"%s", "code":"%s", "state":"%s"}));
+		window.opener.postMessage({ path: "%s", code: "%s", state: "%s"}, window.origin);
 	</script>
   </body>
 </html>


### PR DESCRIPTION
## Overview

This PR updates the scripting in the `form_post` HTML browser response to align with changes made in https://github.com/hashicorp/vault/pull/11884. 

Fixes https://github.com/hashicorp/vault/issues/12239.

## Testing

I tested that this fixes the issue using:
- Azure App Registration 
- [oidc_response_mode](https://www.vaultproject.io/api-docs/auth/jwt#oidc_response_mode) of `form_post`
- [oidc_response_types](https://www.vaultproject.io/api-docs/auth/jwt#oidc_response_types) `id_token`

## Related Issues/PRs

- https://github.com/hashicorp/vault/issues/12239
- https://github.com/hashicorp/vault/pull/11884
