### PR TITLE
Backport 1.7.x: Fixes form_post response mode scripting for browser (#174)

### DIFF
--- a/cli_responses.go
+++ b/cli_responses.go
@@ -449,7 +449,7 @@ func formpostHTML(path, code, state string) string {
       </div>
     </div>
 	<script>
-		window.localStorage.setItem("oidcState", JSON.stringify({"path":"%s", "code":"%s", "state":"%s"}));
+		window.opener.postMessage({ path: "%s", code: "%s", state: "%s"}, window.origin);
 	</script>
   </body>
 </html>


### PR DESCRIPTION
This PR backports a bug fix from #174.

The following steps were taken:
1. `git checkout release/vault-1.7.x`
2. `git checkout -b backport-pr-174-1.7.x`
3. `git cherry-pick 7311fc7f94c5e2d3b32ebc2824b61a782e03edf3`