### PR TITLE
Add a skip_browser argument to make auto-launching of the default browser optional

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -301,7 +301,7 @@ Usage: vault login -method=oidc [CONFIG K=V...]
 Configuration:
 
   role=<string>
-      Vault role of type "OIDC" to use for authentication.
+    Vault role of type "OIDC" to use for authentication.
 
   listenaddress=<string>
     Optional address to bind the OIDC callback listener to (default: localhost).
@@ -316,10 +316,10 @@ Configuration:
     Optional callback host address to use in OIDC redirect_uri (default: localhost).
 
   callbackport=<string>
-      Optional port to to use in OIDC redirect_uri (default: the value set for port).
+    Optional port to to use in OIDC redirect_uri (default: the value set for port).
 
-  no-launch
-      Do not auto-launch default browser with OIDC login address.
+  skip_browser=<bool>
+    Toggle the automatic launching of the default browser to the login URL. (default: false).
 `
 
 	return strings.TrimSpace(help)


### PR DESCRIPTION
# Overview
This change allows a user to opt-out of the auto-launching of their
default browser which may already have a logged in OIDC session. Since
SSO can be a bit tricky to logout/switch users, this provides the user
an escape option for more careful handling of the login attempt.

Primary use-case is Firefox Containers or users using separate browser
profiles to manage multiple logins. If one has an existing SSO session in their default browser,
it becomes impossible to get the vault CLI to login to another session.

# Design of Change
A command line flag was added to allow users to opt-out.

# Related Issues/Pull Requests
None

# Contributor Checklist
[x] https://github.com/hashicorp/vault/pull/12833
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible


**NOTE** I was unable to test the change, I could not find any docs on how to test the client side changes here. If I could get some instruction/direction on how to do that, I'd be happy to confirm it works as intended.