### PR TITLE
Add PKCE to OIDC Auth

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -454,6 +454,13 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 
 	if config.hasType(responseTypeIDToken) {
 		options = append(options, oidc.WithImplicitFlow())
+	} else {
+		v, err := oidc.NewCodeVerifier()
+		if err != nil {
+			return nil, fmt.Errorf("error creating verifier: %w", err)
+		}
+
+		options = append(options, oidc.WithPKCE(v))
 	}
 
 	if role.MaxAge > 0 {

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -454,7 +454,7 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 
 	if config.hasType(responseTypeIDToken) {
 		options = append(options, oidc.WithImplicitFlow())
-	} else {
+	} else if config.hasType(responseTypeCode) {
 		v, err := oidc.NewCodeVerifier()
 		if err != nil {
 			return nil, fmt.Errorf("error creating code challenge: %w", err)

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -457,7 +457,7 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 	} else {
 		v, err := oidc.NewCodeVerifier()
 		if err != nil {
-			return nil, fmt.Errorf("error creating verifier: %w", err)
+			return nil, fmt.Errorf("error creating code challenge: %w", err)
 		}
 
 		options = append(options, oidc.WithPKCE(v))

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -214,7 +214,6 @@ func TestOIDC_AuthURL(t *testing.T) {
 }
 
 func TestOIDC_AuthURL_namespace(t *testing.T) {
-
 	type testCase struct {
 		namespaceInState    string
 		allowedRedirectURIs []string
@@ -365,7 +364,6 @@ func TestOIDC_AuthURL_namespace(t *testing.T) {
 			if !matchState {
 				t.Fatalf("expected state to match regex: %s, %s", test.expectedStateRegEx, state)
 			}
-
 		})
 	}
 }
@@ -586,7 +584,6 @@ func TestOIDC_ResponseTypeIDToken(t *testing.T) {
 
 func TestOIDC_Callback(t *testing.T) {
 	t.Run("successful login", func(t *testing.T) {
-
 		// run test with and without bound_cidrs configured
 		for _, useBoundCIDRs := range []bool{false, true} {
 			b, storage, s := getBackendAndServer(t, useBoundCIDRs)
@@ -623,7 +620,7 @@ func TestOIDC_Callback(t *testing.T) {
 			// save PKCE challenge
 			s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
 
-			// invoke the callback, which will in to try to exchange the code
+			// invoke the callback, which will try to exchange the code
 			// with the mock provider.
 			req = &logical.Request{
 				Operation: logical.ReadOperation,
@@ -1223,7 +1220,7 @@ func TestOIDC_Callback(t *testing.T) {
 	})
 }
 
-// oidcProvider is local server the mocks the basis endpoints used by the
+// oidcProvider is a local server that mocks the basis endpoints used by the
 // OIDC callback process.
 type oidcProvider struct {
 	t             *testing.T

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -3,7 +3,9 @@ package jwtauth
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -101,6 +103,7 @@ func TestOIDC_AuthURL(t *testing.T) {
 				`state=st_\w{20}`,
 				`redirect_uri=https%3A%2F%2Fexample.com`,
 				`response_type=code`,
+				`code_challenge=\w+`,
 				`scope=openid`,
 			}
 
@@ -617,6 +620,9 @@ func TestOIDC_Callback(t *testing.T) {
 			// set mock provider's expected code
 			s.code = "abc"
 
+			// save PKCE challenge
+			s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
+
 			// invoke the callback, which will in to try to exchange the code
 			// with the mock provider.
 			req = &logical.Request{
@@ -711,6 +717,9 @@ func TestOIDC_Callback(t *testing.T) {
 		// set mock provider's expected code
 		s.code = "abc"
 
+		// save PKCE challenge
+		s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
+
 		// invoke the callback, which will in to try to exchange the code
 		// with the mock provider.
 		req = &logical.Request{
@@ -764,6 +773,9 @@ func TestOIDC_Callback(t *testing.T) {
 
 		// set mock provider's expected code
 		s.code = "abc"
+
+		// save PKCE challenge
+		s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
 
 		// invoke the callback, which will in to try to exchange the code
 		// with the mock provider.
@@ -896,6 +908,10 @@ func TestOIDC_Callback(t *testing.T) {
 		// set mock provider's expected code
 		s.code = "abc"
 
+		// save PKCE challenge
+		s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
+
+		// verify failure with wrong code
 		req = &logical.Request{
 			Operation: logical.ReadOperation,
 			Path:      "oidc/callback",
@@ -903,6 +919,58 @@ func TestOIDC_Callback(t *testing.T) {
 			Data: map[string]interface{}{
 				"state": state,
 				"code":  "wrong_code",
+			},
+		}
+		resp, err = b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil || !strings.Contains(resp.Error().Error(), "cannot fetch token") {
+			t.Fatalf("expected code exchange error response, got: %#v", resp)
+		}
+	})
+
+	t.Run("failed code exchange (PKCE)", func(t *testing.T) {
+		b, storage, s := getBackendAndServer(t, false)
+		defer s.server.Close()
+
+		// get auth_url
+		data := map[string]interface{}{
+			"role":         "test",
+			"redirect_uri": "https://example.com",
+		}
+		req := &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "oidc/auth_url",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%v resp:%#v\n", err, resp)
+		}
+
+		authURL := resp.Data["auth_url"].(string)
+		state := getQueryParam(t, authURL, "state")
+
+		// set mock provider's expected code
+		s.code = "abc"
+
+		// Verify failure with failed PKCE verification
+		// The challenge on the request side is embedded in the cap library request state which
+		// is inaccessible. To cause a mismatch, adjust the mock.
+		s.codeChallenge = "wrong_challenge"
+
+		// verify failure with PKCE
+		req = &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "oidc/callback",
+			Storage:   storage,
+			Data: map[string]interface{}{
+				"state": state,
+				"code":  "abc",
 			},
 		}
 		resp, err = b.HandleRequest(context.Background(), req)
@@ -1037,6 +1105,9 @@ func TestOIDC_Callback(t *testing.T) {
 		// set provider claims that will be returned by the mock server
 		s.customClaims = sampleClaims(nonce)
 
+		// save PKCE challenge
+		s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
+
 		req = &logical.Request{
 			Operation: logical.ReadOperation,
 			Path:      "oidc/callback",
@@ -1123,6 +1194,9 @@ func TestOIDC_Callback(t *testing.T) {
 			// set mock provider's expected code
 			s.code = "abc"
 
+			// save PKCE challenge
+			s.codeChallenge = getQueryParam(t, authURL, "code_challenge")
+
 			// invoke the callback, which will try to exchange the code
 			// with the mock provider.
 			req = &logical.Request{
@@ -1152,12 +1226,13 @@ func TestOIDC_Callback(t *testing.T) {
 // oidcProvider is local server the mocks the basis endpoints used by the
 // OIDC callback process.
 type oidcProvider struct {
-	t            *testing.T
-	server       *httptest.Server
-	clientID     string
-	clientSecret string
-	code         string
-	customClaims map[string]interface{}
+	t             *testing.T
+	server        *httptest.Server
+	clientID      string
+	clientSecret  string
+	code          string
+	codeChallenge string
+	customClaims  map[string]interface{}
 }
 
 func newOIDCProvider(t *testing.T) *oidcProvider {
@@ -1190,8 +1265,17 @@ func (o *oidcProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("It's not a keyset!"))
 	case "/token":
 		code := r.FormValue("code")
+		codeVerifier := r.FormValue("code_verifier")
 
 		if code != o.code {
+			w.WriteHeader(401)
+			break
+		}
+
+		sum := sha256.Sum256([]byte(codeVerifier))
+		computedChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+		if computedChallenge != o.codeChallenge {
 			w.WriteHeader(401)
 			break
 		}


### PR DESCRIPTION
# Overview
Add PKCE to OIDC Auth

# Design of Change
use the cap library to set the pkce option

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible


<details>
<summary>Tests</summary>

```
$ make test
VAULT_ACC=1 go test -tags='vault-plugin-auth-jwt' $(go list ./... | grep -v /vendor/) -v  -timeout 10m
=== RUN   TestGetClaim
--- PASS: TestGetClaim (0.00s)
=== RUN   TestExtractMetadata
--- PASS: TestExtractMetadata (0.00s)
=== RUN   TestValidateAudience
--- PASS: TestValidateAudience (0.00s)
=== RUN   TestValidateBoundClaims
--- PASS: TestValidateBoundClaims (0.00s)
=== RUN   Test_normalizeList
--- PASS: Test_normalizeList (0.00s)
=== RUN   TestParseHelp
=== RUN   TestParseHelp/#00
=== RUN   TestParseHelp/#01
=== RUN   TestParseHelp/#02
=== RUN   TestParseHelp/#03
=== RUN   TestParseHelp/#04
=== RUN   TestParseHelp/#05
--- PASS: TestParseHelp (0.00s)
    --- PASS: TestParseHelp/#00 (0.00s)
    --- PASS: TestParseHelp/#01 (0.00s)
    --- PASS: TestParseHelp/#02 (0.00s)
    --- PASS: TestParseHelp/#03 (0.00s)
    --- PASS: TestParseHelp/#04 (0.00s)
    --- PASS: TestParseHelp/#05 (0.00s)
=== RUN   TestConfig_JWT_Read
--- PASS: TestConfig_JWT_Read (0.00s)
=== RUN   TestConfig_JWT_Write
--- PASS: TestConfig_JWT_Write (0.00s)
=== RUN   TestConfig_JWKS_Update
--- PASS: TestConfig_JWKS_Update (0.00s)
=== RUN   TestConfig_JWKS_Update_Invalid
--- PASS: TestConfig_JWKS_Update_Invalid (0.00s)
=== RUN   TestConfig_ResponseMode
--- PASS: TestConfig_ResponseMode (0.00s)
=== RUN   TestConfig_OIDC_Write
--- PASS: TestConfig_OIDC_Write (0.90s)
=== RUN   TestConfig_OIDC_Write_ProviderConfig
=== RUN   TestConfig_OIDC_Write_ProviderConfig/valid_provider_config
=== RUN   TestConfig_OIDC_Write_ProviderConfig/unknown_provider_in_provider_config
=== RUN   TestConfig_OIDC_Write_ProviderConfig/provider_config_missing_provider
=== RUN   TestConfig_OIDC_Write_ProviderConfig/provider_config_not_set
--- PASS: TestConfig_OIDC_Write_ProviderConfig (0.35s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/valid_provider_config (0.12s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/unknown_provider_in_provider_config (0.06s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/provider_config_missing_provider (0.08s)
    --- PASS: TestConfig_OIDC_Write_ProviderConfig/provider_config_not_set (0.09s)
=== RUN   TestConfig_OIDC_Create_Namespace
=== RUN   TestConfig_OIDC_Create_Namespace/namespace_in_state_not_specified
=== RUN   TestConfig_OIDC_Create_Namespace/namespace_in_state_true
=== RUN   TestConfig_OIDC_Create_Namespace/namespace_in_state_false
--- PASS: TestConfig_OIDC_Create_Namespace (0.25s)
    --- PASS: TestConfig_OIDC_Create_Namespace/namespace_in_state_not_specified (0.07s)
    --- PASS: TestConfig_OIDC_Create_Namespace/namespace_in_state_true (0.07s)
    --- PASS: TestConfig_OIDC_Create_Namespace/namespace_in_state_false (0.11s)
=== RUN   TestConfig_OIDC_Update_Namespace
=== RUN   TestConfig_OIDC_Update_Namespace/existing_false,_update_to_true
=== RUN   TestConfig_OIDC_Update_Namespace/existing_false,_update_something_else
=== RUN   TestConfig_OIDC_Update_Namespace/existing_true,_update_to_false
=== RUN   TestConfig_OIDC_Update_Namespace/existing_true,_update_something_else
--- PASS: TestConfig_OIDC_Update_Namespace (0.67s)
    --- PASS: TestConfig_OIDC_Update_Namespace/existing_false,_update_to_true (0.18s)
    --- PASS: TestConfig_OIDC_Update_Namespace/existing_false,_update_something_else (0.17s)
    --- PASS: TestConfig_OIDC_Update_Namespace/existing_true,_update_to_false (0.18s)
    --- PASS: TestConfig_OIDC_Update_Namespace/existing_true,_update_something_else (0.16s)
=== RUN   TestLogin_JWT
2021-11-18T10:40:17.524-0600 [WARN]  unable to locate /org/primary in claims: /org/primary at part 0: couldn't find key "org"
--- PASS: TestLogin_JWT (0.03s)
=== RUN   TestLogin_Leeways
--- PASS: TestLogin_Leeways (0.15s)
=== RUN   TestLogin_JWTSupportedAlgs
=== RUN   TestLogin_JWTSupportedAlgs/JWT_auth_with_empty_signing_algorithms
=== RUN   TestLogin_JWTSupportedAlgs/JWT_auth_with_valid_signing_algorithm
=== RUN   TestLogin_JWTSupportedAlgs/JWT_auth_with_valid_signing_algorithms
=== RUN   TestLogin_JWTSupportedAlgs/JWT_auth_with_invalid_signing_algorithm
=== RUN   TestLogin_JWTSupportedAlgs/JWT_auth_with_invalid_signing_algorithms
--- PASS: TestLogin_JWTSupportedAlgs (0.00s)
    --- PASS: TestLogin_JWTSupportedAlgs/JWT_auth_with_empty_signing_algorithms (0.00s)
    --- PASS: TestLogin_JWTSupportedAlgs/JWT_auth_with_valid_signing_algorithm (0.00s)
    --- PASS: TestLogin_JWTSupportedAlgs/JWT_auth_with_valid_signing_algorithms (0.00s)
    --- PASS: TestLogin_JWTSupportedAlgs/JWT_auth_with_invalid_signing_algorithm (0.00s)
    --- PASS: TestLogin_JWTSupportedAlgs/JWT_auth_with_invalid_signing_algorithms (0.00s)
=== RUN   TestLogin_OIDC
--- SKIP: TestLogin_OIDC (0.15s)
=== RUN   TestLogin_NestedGroups
--- PASS: TestLogin_NestedGroups (0.00s)
=== RUN   TestLogin_OIDC_StringGroupClaim
--- SKIP: TestLogin_OIDC_StringGroupClaim (0.07s)
=== RUN   TestLogin_JWKS_Concurrent
--- PASS: TestLogin_JWKS_Concurrent (0.35s)
=== RUN   TestOIDC_AuthURL
=== RUN   TestOIDC_AuthURL/normal_case
=== PAUSE TestOIDC_AuthURL/normal_case
=== RUN   TestOIDC_AuthURL/missing_role
=== PAUSE TestOIDC_AuthURL/missing_role
=== RUN   TestOIDC_AuthURL/valid_redirect_uri
=== PAUSE TestOIDC_AuthURL/valid_redirect_uri
=== RUN   TestOIDC_AuthURL/invalid_redirect_uri
=== PAUSE TestOIDC_AuthURL/invalid_redirect_uri
=== CONT  TestOIDC_AuthURL/normal_case
=== CONT  TestOIDC_AuthURL/invalid_redirect_uri
=== CONT  TestOIDC_AuthURL/valid_redirect_uri
=== CONT  TestOIDC_AuthURL/missing_role
2021-11-18T10:40:18.419-0600 [WARN]  unauthorized redirect_uri: redirect_uri=http://bitc0in-4-less.cx
--- PASS: TestOIDC_AuthURL (0.16s)
    --- PASS: TestOIDC_AuthURL/missing_role (0.00s)
    --- PASS: TestOIDC_AuthURL/invalid_redirect_uri (0.00s)
    --- PASS: TestOIDC_AuthURL/valid_redirect_uri (0.17s)
    --- PASS: TestOIDC_AuthURL/normal_case (0.17s)
=== RUN   TestOIDC_AuthURL_namespace
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_bad_allowed_redirect
2021-11-18T10:40:19.039-0600 [WARN]  unauthorized redirect_uri: redirect_uri=https://example.com?namespace=test
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state,_bad_allowed_redirect
2021-11-18T10:40:19.443-0600 [WARN]  unauthorized redirect_uri: redirect_uri=https://example.com
=== RUN   TestOIDC_AuthURL_namespace/nested_namespace_in_state
=== RUN   TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_no_namespaces
=== RUN   TestOIDC_AuthURL_namespace/namespace_in_state,_no_namespaces
--- PASS: TestOIDC_AuthURL_namespace (1.72s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter (0.33s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_bad_allowed_redirect (0.12s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state (0.23s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state,_bad_allowed_redirect (0.17s)
    --- PASS: TestOIDC_AuthURL_namespace/nested_namespace_in_state (0.30s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_as_query_parameter,_no_namespaces (0.26s)
    --- PASS: TestOIDC_AuthURL_namespace/namespace_in_state,_no_namespaces (0.30s)
=== RUN   TestOIDC_AuthURL_max_age
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_integer_max_age_of_60
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_integer_max_age_of_180
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_empty_max_age
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_30s
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_2m
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_1hr
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_invalid_duration_string
=== RUN   TestOIDC_AuthURL_max_age/auth_URL_for_role_with_invalid_signed_integer
--- PASS: TestOIDC_AuthURL_max_age (0.29s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_integer_max_age_of_60 (0.15s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_integer_max_age_of_180 (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_empty_max_age (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_30s (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_2m (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_duration_string_max_age_of_1hr (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_invalid_duration_string (0.00s)
    --- PASS: TestOIDC_AuthURL_max_age/auth_URL_for_role_with_invalid_signed_integer (0.00s)
=== RUN   TestOIDC_ResponseTypeIDToken
--- PASS: TestOIDC_ResponseTypeIDToken (0.00s)
=== RUN   TestOIDC_Callback
=== RUN   TestOIDC_Callback/successful_login
=== RUN   TestOIDC_Callback/failed_login_-_bad_nonce
=== RUN   TestOIDC_Callback/failed_login_-_bound_claim_mismatch
=== RUN   TestOIDC_Callback/missing_state
=== RUN   TestOIDC_Callback/unknown_state
=== RUN   TestOIDC_Callback/valid_state,_missing_code
=== RUN   TestOIDC_Callback/failed_code_exchange
=== RUN   TestOIDC_Callback/failed_code_exchange_(PKCE)
=== RUN   TestOIDC_Callback/no_response_from_provider
=== RUN   TestOIDC_Callback/test_bad_address
=== RUN   TestOIDC_Callback/test_invalid_client_id
=== RUN   TestOIDC_Callback/client_nonce
--- PASS: TestOIDC_Callback (0.04s)
    --- PASS: TestOIDC_Callback/successful_login (0.01s)
    --- PASS: TestOIDC_Callback/failed_login_-_bad_nonce (0.00s)
    --- PASS: TestOIDC_Callback/failed_login_-_bound_claim_mismatch (0.00s)
    --- PASS: TestOIDC_Callback/missing_state (0.00s)
    --- PASS: TestOIDC_Callback/unknown_state (0.00s)
    --- PASS: TestOIDC_Callback/valid_state,_missing_code (0.00s)
    --- PASS: TestOIDC_Callback/failed_code_exchange (0.00s)
    --- PASS: TestOIDC_Callback/failed_code_exchange_(PKCE) (0.00s)
    --- PASS: TestOIDC_Callback/no_response_from_provider (0.00s)
    --- PASS: TestOIDC_Callback/test_bad_address (0.00s)
    --- PASS: TestOIDC_Callback/test_invalid_client_id (0.00s)
    --- PASS: TestOIDC_Callback/client_nonce (0.00s)
=== RUN   TestOIDC_ValidRedirect
--- PASS: TestOIDC_ValidRedirect (0.00s)
=== RUN   TestParseMount
--- PASS: TestParseMount (0.00s)
=== RUN   TestPath_Create
=== RUN   TestPath_Create/happy_path
=== RUN   TestPath_Create/no_user_claim
=== RUN   TestPath_Create/no_binding
=== RUN   TestPath_Create/has_bound_subject
=== RUN   TestPath_Create/has_audience
=== RUN   TestPath_Create/has_cidr
=== RUN   TestPath_Create/has_bound_claims
=== RUN   TestPath_Create/has_expiration,_not_before_custom_leeways
=== RUN   TestPath_Create/storing_zero_leeways
=== RUN   TestPath_Create/storing_negative_leeways
=== RUN   TestPath_Create/storing_an_invalid_bound_claim_type
=== RUN   TestPath_Create/role_with_invalid_glob_in_claim
=== RUN   TestPath_Create/role_with_invalid_glob_in_claim_array
--- PASS: TestPath_Create (0.00s)
    --- PASS: TestPath_Create/happy_path (0.00s)
    --- PASS: TestPath_Create/no_user_claim (0.00s)
    --- PASS: TestPath_Create/no_binding (0.00s)
    --- PASS: TestPath_Create/has_bound_subject (0.00s)
    --- PASS: TestPath_Create/has_audience (0.00s)
    --- PASS: TestPath_Create/has_cidr (0.00s)
    --- PASS: TestPath_Create/has_bound_claims (0.00s)
    --- PASS: TestPath_Create/has_expiration,_not_before_custom_leeways (0.00s)
    --- PASS: TestPath_Create/storing_zero_leeways (0.00s)
    --- PASS: TestPath_Create/storing_negative_leeways (0.00s)
    --- PASS: TestPath_Create/storing_an_invalid_bound_claim_type (0.00s)
    --- PASS: TestPath_Create/role_with_invalid_glob_in_claim (0.00s)
    --- PASS: TestPath_Create/role_with_invalid_glob_in_claim_array (0.00s)
=== RUN   TestPath_OIDCCreate
=== RUN   TestPath_OIDCCreate/both_explicit_and_default_role_type
=== RUN   TestPath_OIDCCreate/invalid_reserved_metadata_key_role
=== RUN   TestPath_OIDCCreate/invalid_duplicate_metadata_destination
=== RUN   TestPath_OIDCCreate/custom_expiration_leeway_and_not_before_leeway_values
--- PASS: TestPath_OIDCCreate (0.00s)
    --- PASS: TestPath_OIDCCreate/both_explicit_and_default_role_type (0.00s)
    --- PASS: TestPath_OIDCCreate/invalid_reserved_metadata_key_role (0.00s)
    --- PASS: TestPath_OIDCCreate/invalid_duplicate_metadata_destination (0.00s)
    --- PASS: TestPath_OIDCCreate/custom_expiration_leeway_and_not_before_leeway_values (0.00s)
=== RUN   TestPath_Read
--- PASS: TestPath_Read (0.00s)
=== RUN   TestPath_Delete
--- PASS: TestPath_Delete (0.00s)
=== RUN   TestLogin_fetchGroups
2021-11-18T10:40:20.649-0600 [DEBUG] found Azure Graph API endpoint for group membership: https://127.0.0.1:55517/getMemberObjects
2021-11-18T10:40:20.650-0600 [DEBUG] groups claim raw is [group1 group2]
--- PASS: TestLogin_fetchGroups (0.00s)
=== RUN   Test_getClaimSources
=== RUN   Test_getClaimSources/normal_case
=== RUN   Test_getClaimSources/no__claim_names
2021-11-18T10:40:20.650-0600 [WARN]  unable to locate /_claim_names/groups in claims: /_claim_names/groups at part 0: couldn't find key "_claim_names"
=== RUN   Test_getClaimSources/no__claim_sources
2021-11-18T10:40:20.650-0600 [WARN]  unable to locate /_claim_sources/src1/endpoint in claims: /_claim_sources/src1/endpoint at part 0: couldn't find key "_claim_sources"
--- PASS: Test_getClaimSources (0.00s)
    --- PASS: Test_getClaimSources/normal_case (0.00s)
    --- PASS: Test_getClaimSources/no__claim_names (0.00s)
    --- PASS: Test_getClaimSources/no__claim_sources (0.00s)
=== RUN   TestNewProviderConfig
=== RUN   TestNewProviderConfig/normal_case
=== RUN   TestNewProviderConfig/no_provider_config
=== RUN   TestNewProviderConfig/provider_field_not_present_in_provider_config
=== RUN   TestNewProviderConfig/unknown_provider
=== RUN   TestNewProviderConfig/provider_name_not_present_in_provider_config
=== RUN   TestNewProviderConfig/error_in_Initialize
--- PASS: TestNewProviderConfig (0.00s)
    --- PASS: TestNewProviderConfig/normal_case (0.00s)
    --- PASS: TestNewProviderConfig/no_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/provider_field_not_present_in_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/unknown_provider (0.00s)
    --- PASS: TestNewProviderConfig/provider_name_not_present_in_provider_config (0.00s)
    --- PASS: TestNewProviderConfig/error_in_Initialize (0.00s)
=== RUN   TestGSuiteProvider_FetchGroups
    provider_gsuite_test.go:27: skip: must set env var "GOOGLE_CREDENTIALS" to a valid service account key file path
--- SKIP: TestGSuiteProvider_FetchGroups (0.00s)
=== RUN   TestGSuiteProvider_FetchUserInfo
    provider_gsuite_test.go:27: skip: must set env var "GOOGLE_CREDENTIALS" to a valid service account key file path
--- SKIP: TestGSuiteProvider_FetchUserInfo (0.00s)
=== RUN   TestGSuiteProvider_search
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_that's_in_no_groups
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_that's_in_no_groups
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_default_recursion_max_depth_0
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_1
=== RUN   TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_10
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_default_recursion_max_depth_0
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_1
=== RUN   TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_10
--- PASS: TestGSuiteProvider_search (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_that's_in_no_groups (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_that's_in_no_groups (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_default_recursion_max_depth_0 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_1 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_user_with_recursion_max_depth_10 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_default_recursion_max_depth_0 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_1 (0.00s)
    --- PASS: TestGSuiteProvider_search/fetch_groups_for_group_with_recursion_max_depth_10 (0.00s)
=== RUN   TestGSuiteProvider_Initialize
=== RUN   TestGSuiteProvider_Initialize/invalid_config:_required_service_account_key_is_empty
=== RUN   TestGSuiteProvider_Initialize/invalid_config:_required_admin_impersonate_email_is_empty
=== RUN   TestGSuiteProvider_Initialize/invalid_config:_recurse_max_depth_negative_number
=== RUN   TestGSuiteProvider_Initialize/valid_config:_all_options
=== RUN   TestGSuiteProvider_Initialize/valid_config:_no_custom_schemas
=== RUN   TestGSuiteProvider_Initialize/valid_config:_no_recurse_max_depth
=== RUN   TestGSuiteProvider_Initialize/valid_config:_fetch_groups_and_user_info
--- PASS: TestGSuiteProvider_Initialize (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/invalid_config:_required_service_account_key_is_empty (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/invalid_config:_required_admin_impersonate_email_is_empty (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/invalid_config:_recurse_max_depth_negative_number (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/valid_config:_all_options (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/valid_config:_no_custom_schemas (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/valid_config:_no_recurse_max_depth (0.00s)
    --- PASS: TestGSuiteProvider_Initialize/valid_config:_fetch_groups_and_user_info (0.00s)
=== RUN   TestGSuiteProvider_validateBoundClaims
2021-11-18T10:40:20.653-0600 [DEBUG] fetched G Suite groups: groups=[group1@example.com]
--- PASS: TestGSuiteProvider_validateBoundClaims (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-auth-jwt	8.790s
?   	github.com/hashicorp/vault-plugin-auth-jwt/cmd/vault-plugin-auth-jwt	[no test files]
```

</details>
