### PR TITLE
Backport 1.9.x: Add PKCE to OIDC Auth (#188)

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -454,6 +454,13 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 
 	if config.hasType(responseTypeIDToken) {
 		options = append(options, oidc.WithImplicitFlow())
+	} else if config.hasType(responseTypeCode) {
+		v, err := oidc.NewCodeVerifier()
+		if err != nil {
+			return nil, fmt.Errorf("error creating code challenge: %w", err)
+		}
+
+		options = append(options, oidc.WithPKCE(v))
 	}
 
 	if role.MaxAge > 0 {


### PR DESCRIPTION
This PR backports #188 

The following steps were taken:
1. `git checkout release/vault-1.9.x`
2. `git checkout -b backport-pr-188-1.9.x`
3. `git cherry-pick 7010da264993747d78ec4fab83505abab0b97c25`