### PR TITLE
Backport 1.9.x: Adds UI postMessage source required for implicit flow (#192)

### DIFF
--- a/cli_responses.go
+++ b/cli_responses.go
@@ -449,7 +449,7 @@ func formpostHTML(path, code, state string) string {
       </div>
     </div>
 	<script>
-		window.opener.postMessage({ path: "%s", code: "%s", state: "%s"}, window.origin);
+		window.opener.postMessage({ source: 'oidc-callback', path: "%s", code: "%s", state: "%s"}, window.origin);
 	</script>
   </body>
 </html>


### PR DESCRIPTION
This PR backports #192.

Steps:
1. `git checkout release/vault-1.9.x`
2. `git checkout -b backport-pr-192-1.9.x`
3. `git cherry-pick 6bd8f3169efdcc0f2f9ea1264e8182026c8c9bb1`