### PR TITLE
Return nil if no warnings when creating roles

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -561,6 +561,10 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		return nil, err
 	}
 
+	if len(resp.Warnings) == 0 {
+		return nil, nil
+	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
A simple bug fix. The /role/ path doesn't return success because we get an empty secret interface returned instead of nil. To fix this we just return nil,nil when no warnings are present.

Who the change affects or is for (stakeholders)?
This affects those who are programmatically checking the cli commands to see if roles were successfully written. 

What is the change? 
return nil,nil when no warnings are present when creating roles

Why is the change needed?
So, users can know whether their roles were successfully written to vault

How does this change affect the user experience (if at all)?
Users won't know if their roles were successfully written. If they want to programmatically check for it, they need to list all roles. 

# Design of Change
How was this change implemented?
Return nil,nil if no warnings

# Related Issues/Pull Requests
[x] [Issue #15107](https://github.com/hashicorp/vault/issues/15107)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
