### PR TITLE
Azure provider - Add Support for US Gov L4

### DIFF
--- a/provider_azure.go
+++ b/provider_azure.go
@@ -16,10 +16,12 @@ import (
 
 const (
 	// Deprecated: The host of the Azure Active Directory (AAD) graph API
-	azureADGraphHost = "graph.windows.net"
+	azureADGraphHost   = "graph.windows.net"
+	azureADGraphUShost = "https://graph.microsoftazure.us"
 
 	// The host and version of the Microsoft Graph API
 	microsoftGraphHost       = "graph.microsoft.com"
+	microsoftGraphUSHost     = "graph.microsoft.us"
 	microsoftGraphAPIVersion = "/v1.0"
 
 	// Distributed claim fields
@@ -116,6 +118,9 @@ func (a *AzureProvider) getClaimSource(logger log.Logger, allClaims map[string]i
 	// - https://docs.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0
 	if urlParsed.Host == azureADGraphHost {
 		urlParsed.Host = microsoftGraphHost
+		urlParsed.Path = microsoftGraphAPIVersion + urlParsed.Path
+	} else if urlParsed.Host == azureADGraphUShost {
+		urlParsed.Host = microsoftGraphUSHost
 		urlParsed.Path = microsoftGraphAPIVersion + urlParsed.Path
 	}
 


### PR DESCRIPTION
The azure provider has some code to correctly identify and convert the Azure AD Graph host to the MS Graph host. For reasons unknown to me, Microsoft will not update the JWT to correctly send MS Graph URLs either though AD Graph is deprecated. 

This PR extends the current conversion to support the US Gov cloud offering (https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-request-differences) 