### PR TITLE
Update CLIHandler.Auth() to support aborting on any error

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -204,7 +204,7 @@ func callbackHandler(c *api.Client, mount string, clientNonce string, doneCh cha
 	}
 }
 
-func fetchAuthURL(c *api.Client, role, mount, callbackport string, callbackMethod string, callbackHost string) (string, string, error) {
+func fetchAuthURL(c *api.Client, role, mount, callbackPort string, callbackMethod string, callbackHost string) (string, string, error) {
 	var authURL string
 
 	clientNonce, err := base62.Random(20)
@@ -212,7 +212,7 @@ func fetchAuthURL(c *api.Client, role, mount, callbackport string, callbackMetho
 		return "", "", err
 	}
 
-	redirectURI := fmt.Sprintf("%s://%s:%s/oidc/callback", callbackMethod, callbackHost, callbackport)
+	redirectURI := fmt.Sprintf("%s://%s:%s/oidc/callback", callbackMethod, callbackHost, callbackPort)
 	data := map[string]interface{}{
 		"role":         role,
 		"redirect_uri": redirectURI,

--- a/cli.go
+++ b/cli.go
@@ -81,27 +81,30 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		callbackPort = port
 	}
 
-	parseBool := func(f string) (bool, error) {
-		if s, ok := m[f]; ok {
-			v, err := strconv.ParseBool(s)
-			if err != nil {
-				return false, fmt.Errorf(
-					"failed to parse value for %q, err=%w", f, err)
-			}
-			return v, nil
+	parseBool := func(f string, d bool) (bool, error) {
+		s, ok := m[f]
+		if !ok {
+			return d, nil
 		}
-		return false, nil
+
+		v, err := strconv.ParseBool(s)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to parse value for %q, err=%w", f, err)
+		}
+
+		return v, nil
 	}
 
 	var skipBrowserLaunch bool
-	if v, err := parseBool(FieldSkipBrowser); err != nil {
+	if v, err := parseBool(FieldSkipBrowser, false); err != nil {
 		return nil, err
 	} else {
 		skipBrowserLaunch = v
 	}
 
 	var abortOnError bool
-	if v, err := parseBool(FieldAbortOnError); err != nil {
+	if v, err := parseBool(FieldAbortOnError, false); err != nil {
 		return nil, err
 	} else {
 		abortOnError = v


### PR DESCRIPTION
In order to make `CLIHandler.Auth()` work in a fully non-interactive context, i.e. from the Terraform Vault Provider, it needs to be able to abort on any error encountered. This PR adds support for a new parameter `abort_on_error` to control the new behavior.

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[X] Backwards compatible
