### PR TITLE
Adds ability to set Google workspace domain for groups search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
-IMPROVEMENTS:
+## 0.15.0
+
+* Adds ability to set Google Workspace domain for groups search [[GH-220]](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/220)
+
+## 0.14.0
 
 * Updates dependency `google.golang.org/api@v0.83.0` [[GH-205](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/205)]
 * Add Custom Provider for SecureAuth IdP [[GH-196](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/196)]


### PR DESCRIPTION
## Overview

This PR adds the ability to set the Google workspace domain for groups search.

Addresses https://github.com/hashicorp/vault-plugin-auth-jwt/issues/216.

# Related Issues/Pull Requests
- https://github.com/hashicorp/vault-plugin-auth-jwt/issues/216

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository
  - Will add docs
- [x] Backwards compatible
