### PR TITLE
Support ADC for Google Workspace (dwd/no-dwd)

### DIFF
--- a/provider_gsuite.go
+++ b/provider_gsuite.go
@@ -45,8 +45,8 @@ type GSuiteProviderConfig struct {
 	// Workspace Directory API through domain-wide delegation of authority,
 	// without using a service account key. The service account vault is
 	// running under must be granted the `iam.serviceAccounts.signJwt`
-	// permission on this service account. If AdminEmail is specifed, that
-	// Workspace user will be impersonated.
+	// permission on this service account. If AdminImpersonateEmail is
+	// specifed, that Workspace user will be impersonated.
 	ImpersonatePrincipal string `mapstructure:"impersonate_principal"`
 
 	// If set to true, groups will be fetched from the Google Workspace
@@ -122,15 +122,15 @@ func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 			Subject:         config.AdminImpersonateEmail,
 		})
 		if err != nil {
-			return fmt.Errorf("impersonate %q: %w", config.ImpersonatePrincipal, err)
+			return fmt.Errorf("failed to impersonate principal: %q: %w", config.ImpersonatePrincipal, err)
 		}
 
 		ts = its
-	// Assume Aplication Default Credentials and no impersonation.
+	// Assume Application Default Credentials and no impersonation.
 	default:
 		creds, err := google.FindDefaultCredentials(ctx, scopes...)
 		if err != nil {
-			return fmt.Errorf("find application default credentials: %w", err)
+			return fmt.Errorf("failed to find application default credentials: %w", err)
 		}
 
 		ts = creds.TokenSource

--- a/provider_gsuite.go
+++ b/provider_gsuite.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 )
 
@@ -29,16 +30,31 @@ type GSuiteProvider struct {
 
 // GSuiteProviderConfig represents the configuration for a GSuiteProvider.
 type GSuiteProviderConfig struct {
-	// The path to or contents of a Google service account key file. Required.
+	// The path to or contents of a Google service account key file. Optional.
+	// If left unspecified, Application Default Credentials will be used.
 	ServiceAccount string `mapstructure:"gsuite_service_account"`
 
-	// Email address of a G Suite admin to impersonate. Required.
+	// Email address of a Google Workspace user that has access to read users
+	// and groups for the organization in the Google Workspace Directory API.
+	// Required if accessing the Google Workspace Directory API through
+	// domain-wide delegation of authority.
 	AdminImpersonateEmail string `mapstructure:"gsuite_admin_impersonate"`
 
-	// If set to true, groups will be fetched from G Suite.
+	// Service account email that has been granted domain-wide delegation of
+	// authority in Google Workspace. Required if accessing the Google
+	// Workspace Directory API through domain-wide delegation of authority,
+	// without using a service account key. The service account vault is
+	// running under must be granted the `iam.serviceAccounts.signJwt`
+	// permission on this service account. If AdminEmail is specifed, that
+	// Workspace user will be impersonated.
+	ImpersonatePrincipal string `mapstructure:"impersonate_principal"`
+
+	// If set to true, groups will be fetched from the Google Workspace
+	// Directory API.
 	FetchGroups bool `mapstructure:"fetch_groups"`
 
-	// If set to true, user info will be fetched from G Suite using UserCustomSchemas.
+	// If set to true, user info will be fetched from the Google Workspace
+	// Directory API using UserCustomSchemas.
 	FetchUserInfo bool `mapstructure:"fetch_user_info"`
 
 	// Group membership recursion max depth (0 = do not recurse).
@@ -61,28 +77,8 @@ func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 	}
 
 	// Validate configuration
-	if config.ServiceAccount == "" {
-		return errors.New("'gsuite_service_account' must be either the path to or contents of " +
-			"a JSON service account key file")
-	}
-	if config.AdminImpersonateEmail == "" {
-		return errors.New("'gsuite_admin_impersonate' must be set to an email address of a " +
-			"G Suite user with 'Read' permission to access the G Suite Admin User and Group APIs")
-	}
 	if config.GroupsRecurseMaxDepth < 0 {
 		return errors.New("'gsuite_recurse_max_depth' must be a positive integer")
-	}
-
-	// A file path or JSON string may be provided for the service account parameter.
-	// Check to see if a file exists at the given path, and if so, read its contents.
-	// Otherwise, assume the service account has been provided as a JSON string.
-	var err error
-	keyJSON := []byte(config.ServiceAccount)
-	if fileExists(config.ServiceAccount) {
-		keyJSON, err = ioutil.ReadFile(config.ServiceAccount)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Set the requested scopes
@@ -90,24 +86,62 @@ func (g *GSuiteProvider) Initialize(ctx context.Context, jc *jwtConfig) error {
 		admin.AdminDirectoryGroupReadonlyScope,
 		admin.AdminDirectoryUserReadonlyScope,
 	}
+	g.config = config
 
-	// Create the google JWT config from the service account
-	jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
-	if err != nil {
-		return fmt.Errorf("error parsing service account JSON: %w", err)
+	var ts oauth2.TokenSource
+	switch {
+	// A file path or JSON string may be provided for the service account parameter.
+	// Check to see if a file exists at the given path, and if so, read its contents.
+	// Otherwise, assume the service account has been provided as a JSON string.
+	case config.ServiceAccount != "":
+		var err error
+		keyJSON := []byte(config.ServiceAccount)
+		if fileExists(config.ServiceAccount) {
+			keyJSON, err = ioutil.ReadFile(config.ServiceAccount)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Create the google JWT config from the service account
+		jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+		if err != nil {
+			return fmt.Errorf("error parsing service account JSON: %w", err)
+		}
+
+		// Set the subject to impersonate
+		jwtConfig.Subject = config.AdminImpersonateEmail
+
+		ts = jwtConfig.TokenSource(ctx)
+	// We are performing impersonation of a Workspace user through domain-wide
+	// delegation of authority.
+	case config.ImpersonatePrincipal != "":
+		its, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+			TargetPrincipal: config.ImpersonatePrincipal,
+			Scopes:          scopes,
+			Subject:         config.AdminImpersonateEmail,
+		})
+		if err != nil {
+			return fmt.Errorf("impersonate %q: %w", config.ImpersonatePrincipal, err)
+		}
+
+		ts = its
+	// Assume Aplication Default Credentials and no impersonation.
+	default:
+		creds, err := google.FindDefaultCredentials(ctx, scopes...)
+		if err != nil {
+			return fmt.Errorf("find application default credentials: %w", err)
+		}
+
+		ts = creds.TokenSource
 	}
 
-	// Set the subject to impersonate
-	jwtConfig.Subject = config.AdminImpersonateEmail
-
-	// Create a new admin service for requests to Google admin APIs
-	svc, err := admin.NewService(ctx, option.WithHTTPClient(jwtConfig.Client(ctx)))
+	svc, err := admin.NewService(ctx, option.WithTokenSource(ts))
 	if err != nil {
 		return err
 	}
-
 	g.adminSvc = svc
-	g.config = config
+
 	return nil
 }
 

--- a/provider_gsuite_test.go
+++ b/provider_gsuite_test.go
@@ -412,32 +412,6 @@ func TestGSuiteProvider_Initialize(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "invalid config: required service account key is empty",
-			args: args{
-				config: &jwtConfig{
-					ProviderConfig: map[string]interface{}{
-						"gsuite_admin_impersonate": "test@example.com",
-						"groups_recurse_max_depth": -1,
-						"user_custom_schemas":      "Custom",
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid config: required admin impersonate email is empty",
-			args: args{
-				config: &jwtConfig{
-					ProviderConfig: map[string]interface{}{
-						"gsuite_service_account":   `{"type": "service_account"}`,
-						"groups_recurse_max_depth": -1,
-						"user_custom_schemas":      "Custom",
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name: "invalid config: recurse max depth negative number",
 			args: args{
 				config: &jwtConfig{


### PR DESCRIPTION
# Overview
This commit adds support for authenticating to the Google Workspace Directory API through [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). ADC is assumed if `ServiceAccount` is left empty.

Authentication can be performed through domain-wide delegation of authority by impersonating a workspace user, or directly by granting the service account the necessary admin roles.

See the [docs](https://cloud.google.com/identity/docs/how-to/setup#auth-no-dwd) for authenticating as a service account without domain-wide delegation of authority.

This commit introduces a new config field,`ImpersonatePrincipal`. This field is used as a target service account to create a signed JWT for the Workspace user to impersonate. This is useful in a scenario where you are doing ADC with [External Account Credentials](https://google.aip.dev/auth/4117) but still need to impersonate a Workspace user through DWDoA. Since you don't have access to the service account's private key, you need an extra hop to the Service Account Credentials API to generate the signed JWT.

# Related Issues/Pull Requests
- #139 

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[Docs commit](https://github.com/pgsgeo/vault/commit/a2a626a8a33dd72e93e45251b62d575e1b763dcb)
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
