### PR TITLE
chore: add errcheck for parsing cli flags

### DIFF
--- a/cmd/vault-plugin-auth-jwt/main.go
+++ b/cmd/vault-plugin-auth-jwt/main.go
@@ -15,7 +15,11 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:]) // Ignore command, strictly parse flags
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags. If `flags.Parse()` fails now the error is hidden from the user.

# Design of Change

An error check was missing and I added it 👍

# Related Issues/Pull Requests

Originally noticed at https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202

# Contributor Checklist
[-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
Not needed

[-] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
Not needed

[x] Backwards compatible
