### PR TITLE
Add missing `Query: true` metadata to API definitions

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -65,16 +65,21 @@ func pathOIDC(b *jwtAuthBackend) []*framework.Path {
 
 			Fields: map[string]*framework.FieldSchema{
 				"state": {
-					Type: framework.TypeString,
+					Type:  framework.TypeString,
+					Query: true,
 				},
 				"code": {
-					Type: framework.TypeString,
+					Type:  framework.TypeString,
+					Query: true,
 				},
 				"id_token": {
 					Type: framework.TypeString,
+					// This one is not "Query: true" as it is only consumed by the UpdateOperation,
+					// not the ReadOperation
 				},
 				"client_nonce": {
-					Type: framework.TypeString,
+					Type:  framework.TypeString,
+					Query: true,
 				},
 			},
 
@@ -91,7 +96,7 @@ func pathOIDC(b *jwtAuthBackend) []*framework.Path {
 					Summary:  "Callback endpoint to handle form_posts.",
 
 					DisplayAttrs: &framework.DisplayAttributes{
-						OperationSuffix: "with-parameters",
+						OperationSuffix: "form-post",
 					},
 
 					// state is cached so don't process OIDC logins on perf standbys


### PR DESCRIPTION
As described in hashicorp/vault#21949 endpoints with non-path parameters
that can be made use of during ReadOperation callbacks should have those
fields marked as `Query: true` to ensure the OpenAPI spec truly reflects
how the endpoints can be called.

This should also provide a proper fix to hashicorp/vault-client-go#155.

I'm also changing the operation ID to reflect that GET and POST on
`oidc/callback` are **not** at all the same operation with and without
parameters, but in fact play substantially different roles in the
overall OIDC login flow.
