### PR TITLE
Close HTTP listener if stop signal received

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/hashicorp/cap/util"
@@ -51,7 +52,7 @@ type loginResp struct {
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
 	// handle ctrl-c while waiting for the callback
 	sigintCh := make(chan os.Signal, 1)
-	signal.Notify(sigintCh, os.Interrupt)
+	signal.Notify(sigintCh, os.Interrupt, os.Kill, syscall.SIGTSTP)
 	defer signal.Stop(sigintCh)
 
 	mount, ok := m["mount"]
@@ -152,7 +153,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		}
 	}()
 
-	// Wait for either the callback to finish, SIGINT to be received or up to 2 minutes
+	// Wait for either the callback to finish, SIGINT, SIGKILL, or SIGTSTP to be received or up to 2 minutes
 	select {
 	case s := <-doneCh:
 		return s.secret, s.err


### PR DESCRIPTION
# Overview

If a CLI user issues a stop signal (SIGTSTP usually via Ctrl-Z) instead of an interrupt signal (SIGINT usually via Ctrl-C), the process will indefinitely hold the OIDC callback listener port until the process is forcibly killed or the process is resumed and the timeout is achieved.

Most users won't notice these changes or they will never have experienced this because: 1) they are running this locally without `skip_browser=true` or 2) they're not working in a shared environment. There are other areas where this issue could arise, but these are the most common. This change is mainly for system administrators so that the port cannot be unintentionally held by a user issuing the incorrect command to stop the login flow.

# Design of Change

This change closes the listener when a SIGTSTP signal is received. Additionally, it also closes the listener when `os.Kill` is received. These changes make it so that in a shared environment, system administrators do not need to get involved to forcibly kill a process or instruct a user to resume the process and issue Ctrl-C or wait for the timeout.

# Related Issues/Pull Requests
Fixes #250 

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet

I don't believe this change requires documentation updates as no existing functionality is impacted.

- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

1. Clone the Vault repo at https://github.com/hashicorp/vault.
2. Modify the `go.mod` file in the Vault repo with a replace directive to point to a repo that has this revision.
3. Execute `go run . login -method oidc skip_browser=true`, ensuring that you are pointing to a Vault instance with OIDC configured.

```shell-session
$ go run . login -method oidc skip_browser=true
Complete the login via your OIDC provider. Open the following link in your browser:

    <redacted-URL>


Waiting for OIDC authentication to complete...
```

4. Issue a Ctrl-Z command. The following is added to the output above.

```text
Error authenticating: Interrupted

[1]  + 37325 suspended  go run . login -method oidc skip_browser=true
```

5. Run step 3 from above again. You shouldn't get an error about the port being held anymore.

- [x] Backwards compatible