### PR TITLE
Support numeric claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.18.0
 
 IMPROVEMENTS:
+* Add support for numeric claims in bound_claims https://github.com/hashicorp/vault-plugin-auth-jwt/pull/265
 * Include role name in Entity Alias metadata https://github.com/hashicorp/vault-plugin-auth-jwt/pull/160
 * Updated dependencies:
   * `github.com/hashicorp/cap` v0.3.4 -> v0.4.0

--- a/claims.go
+++ b/claims.go
@@ -66,6 +66,7 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 
 	switch v := val.(type) {
 	case float32:
+		return strconv.Itoa(int(v))
 	case float64:
 		return strconv.Itoa(int(v))
 	}

--- a/claims.go
+++ b/claims.go
@@ -4,6 +4,7 @@
 package jwtauth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -54,21 +55,13 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 	// The claims unmarshalled by go-oidc don't use UseNumber, so there will
 	// be mismatches if they're coming in as float64 since Vault's config will
 	// be represented as json.Number. If the operator can coerce claims data to
-	// be in string form, there is no problem. Alternatively, we could try to
-	// intelligently convert float64 to json.Number, e.g.:
-	//
-	// switch v := val.(type) {
-	// case float64:
-	// 	val = json.Number(strconv.Itoa(int(v)))
-	// }
-	//
-	// Or we fork and/or PR go-oidc.
-
+	// be in string form, there is no problem. As an alternative, we try to
+	// intelligently convert float32 and float64 to json.Number:
 	switch v := val.(type) {
 	case float32:
-		return strconv.Itoa(int(v))
+		return json.Number(strconv.Itoa(int(v)))
 	case float64:
-		return strconv.Itoa(int(v))
+		return json.Number(strconv.Itoa(int(v)))
 	}
 	return val
 }
@@ -129,12 +122,12 @@ func validateBoundClaims(logger log.Logger, boundClaimsType string, boundClaims,
 
 		actVals, ok := normalizeList(actValue)
 		if !ok {
-			return fmt.Errorf("received claim is not a string or list: %v", actValue)
+			return fmt.Errorf("received claim is not a string, bool, int or list: %v", actValue)
 		}
 
 		expVals, ok := normalizeList(expValue)
 		if !ok {
-			return fmt.Errorf("bound claim is not a string or list: %v", expValue)
+			return fmt.Errorf("bound claim is not a string, bool, int or list: %v", expValue)
 		}
 
 		found, err := matchFound(expVals, actVals, useGlobs)
@@ -175,7 +168,7 @@ func matchFound(expVals, actVals []interface{}, useGlobs bool) (bool, error) {
 	return false, nil
 }
 
-// normalizeList takes a string, bool or list and returns a list. This is useful when
+// normalizeList takes a string, bool, json.Number or list and returns a list. This is useful when
 // providers are expected to return a list (typically of strings) but reduce it
 // to a string type when the list count is 1.
 func normalizeList(raw interface{}) ([]interface{}, bool) {
@@ -184,7 +177,7 @@ func normalizeList(raw interface{}) ([]interface{}, bool) {
 	switch v := raw.(type) {
 	case []interface{}:
 		normalized = v
-	case string, bool:
+	case string, bool, json.Number:
 		normalized = []interface{}{v}
 	default:
 		return nil, false

--- a/claims.go
+++ b/claims.go
@@ -6,6 +6,7 @@ package jwtauth
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
@@ -63,6 +64,11 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 	//
 	// Or we fork and/or PR go-oidc.
 
+	switch v := val.(type) {
+	case float32:
+	case float64:
+		return strconv.Itoa(int(v))
+	}
 	return val
 }
 

--- a/claims_test.go
+++ b/claims_test.go
@@ -37,10 +37,10 @@ func TestGetClaim(t *testing.T) {
 		claim string
 		value interface{}
 	}{
-		{"a", float64(42)},
-		{"/a", float64(42)},
+		{"a", "42"},
+		{"/a", "42"},
 		{"b", "bar"},
-		{"/c/d", float64(95)},
+		{"/c/d", "95"},
 		{"/c/e/1", "cat"},
 		{"/c/f/g", "zebra"},
 		{"nope", nil},
@@ -83,10 +83,10 @@ func TestSetClaim(t *testing.T) {
 		claim string
 		value interface{}
 	}{
-		{"a", float64(43)},
-		{"/a", float64(43)},
+		{"a", "43"},
+		{"/a", "43"},
 		{"b", "foo"},
-		{"/c/d", float64(96)},
+		{"/c/d", "96"},
 		{"/c/e/1", "dog"},
 		{"/c/f/g", "elephant"},
 	}

--- a/claims_test.go
+++ b/claims_test.go
@@ -37,10 +37,10 @@ func TestGetClaim(t *testing.T) {
 		claim string
 		value interface{}
 	}{
-		{"a", "42"},
-		{"/a", "42"},
+		{"a", json.Number("42")},
+		{"/a", json.Number("42")},
 		{"b", "bar"},
-		{"/c/d", "95"},
+		{"/c/d", json.Number("95")},
 		{"/c/e/1", "cat"},
 		{"/c/f/g", "zebra"},
 		{"nope", nil},
@@ -83,10 +83,10 @@ func TestSetClaim(t *testing.T) {
 		claim string
 		value interface{}
 	}{
-		{"a", "43"},
-		{"/a", "43"},
+		{"a", json.Number("43")},
+		{"/a", json.Number("43")},
 		{"b", "foo"},
-		{"/c/d", "96"},
+		{"/c/d", json.Number("96")},
 		{"/c/e/1", "dog"},
 		{"/c/f/g", "elephant"},
 	}

--- a/claims_test.go
+++ b/claims_test.go
@@ -292,6 +292,54 @@ func TestValidateBoundClaims(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:            "valid match with numeric claim conversion from float64",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				// Numeric bound claims from Vault API are json.Number type
+				"foo": json.Number("123"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float64(123),
+			},
+			errExpected: false,
+		},
+		{
+			name:            "valid match with numeric claim conversion from float32",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				// Numeric bound claims from Vault API are json.Number type
+				"foo": json.Number("123"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float32(123),
+			},
+			errExpected: false,
+		},
+		{
+			name:            "invalid match with numeric claim conversion from float64",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				// Numeric bound claims from Vault API are json.Number type
+				"foo": json.Number("456"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float64(123),
+			},
+			errExpected: true,
+		},
+		{
+			name:            "invalid match with numeric claim conversion from float32",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				// Numeric bound claims from Vault API are json.Number type
+				"foo": json.Number("123"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float32(456),
+			},
+			errExpected: true,
+		},
+		{
 			name:            "invalid - no match within list",
 			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -123,7 +123,7 @@ func setupBackend(t *testing.T, cfg testConfig) (closeableBackend, logical.Stora
 	if cfg.boundClaims {
 		data["bound_claims"] = map[string]interface{}{
 			"color": "green",
-			"pnum":  "123",
+			"pnum":  json.Number("123"),
 		}
 	}
 	if cfg.boundCIDRs {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -123,6 +123,7 @@ func setupBackend(t *testing.T, cfg testConfig) (closeableBackend, logical.Stora
 	if cfg.boundClaims {
 		data["bound_claims"] = map[string]interface{}{
 			"color": "green",
+			"pnum":  "123",
 		}
 	}
 	if cfg.boundCIDRs {
@@ -348,17 +349,19 @@ func testLogin_JWT(t *testing.T, jwks bool) {
 			}
 
 			privateCl := struct {
-				User      string   `json:"https://vault/user"`
-				Groups    []string `json:"https://vault/groups"`
-				FirstName string   `json:"first_name"`
-				Org       orgs     `json:"org"`
-				Color     string   `json:"color"`
+				User          string   `json:"https://vault/user"`
+				Groups        []string `json:"https://vault/groups"`
+				FirstName     string   `json:"first_name"`
+				Org           orgs     `json:"org"`
+				Color         string   `json:"color"`
+				ProjectNumber int      `json:"pnum"`
 			}{
 				"jeff",
 				[]string{"foo", "bar"},
 				"jeff2",
 				orgs{"engineering"},
 				"green",
+				123,
 			}
 
 			jwtData, _ := getTestJWT(t, ecdsaPrivKey, cl, privateCl)


### PR DESCRIPTION
# Overview
The OIDC/JWT plugin does not support `bound_claims` other than strings or bools: https://github.com/hashicorp/vault-plugin-auth-jwt/blob/main/claims.go#L130. However, I encountered a JWT, which contains a numeric claim, which I want to bind to. 

I think it makes sense to support numeric bound claims - in fact, this was the original idea laid out in this comment: https://github.com/hashicorp/vault-plugin-auth-jwt/pull/24/files#r256926892

![image](https://github.com/hashicorp/vault-plugin-auth-jwt/assets/878624/9d3d18d4-3954-49a2-83bf-2d13437ebed3)

# Design of Change
We are adding support for numeric claims in `bound_claims`.

# Related Issues/Pull Requests:  
None

# Contributor Checklist
[X] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
No changes are needed in the documentation since it doesn't go into the details of what is/not supported in the bound claims.
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[X] Backwards compatible
Numeric claims are currently not supported (they result in error), so this change only applies going forward.
