### PR TITLE
Adds changelog entry for v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Unreleased
 
+## v0.19.0
+
+IMPROVEMENTS:
+* Add support for numeric claims in `bound_claims` https://github.com/hashicorp/vault-plugin-auth-jwt/pull/265
+
 ## v0.18.0
 
 IMPROVEMENTS:
-* Add support for numeric claims in bound_claims https://github.com/hashicorp/vault-plugin-auth-jwt/pull/265
 * Include role name in Entity Alias metadata https://github.com/hashicorp/vault-plugin-auth-jwt/pull/160
 * Updated dependencies:
   * `github.com/hashicorp/cap` v0.3.4 -> v0.4.0


### PR DESCRIPTION
This PR adds a changelog entry for the [v0.19.0](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.19.0) release of the plugin.