### PR TITLE
make redirect uri validation case-insensitve

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -538,7 +538,7 @@ func (b *jwtAuthBackend) verifyOIDCRequest(stateID string) *oidcRequest {
 	return nil
 }
 
-func isLoopbackAddress(hostname string) bool {
+func isLocalAddr(hostname string) bool {
 	ip := net.ParseIP(hostname)
 	if ip != nil {
 		return ip.IsLoopback()
@@ -558,7 +558,7 @@ func validRedirect(uri string, allowed []string) bool {
 	}
 
 	// if uri isn't a loopback, just string search the allowed list
-	if !isLoopbackAddress(inputURI.Hostname()) {
+	if !isLocalAddr(inputURI.Hostname()) {
 		return strutil.StrListContainsCaseInsensitive(allowed, uri)
 	}
 

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -547,7 +547,7 @@ func validRedirect(uri string, allowed []string) bool {
 
 	// if uri isn't a loopback, just string search the allowed list
 	if !strutil.StrListContains([]string{"localhost", "127.0.0.1", "::1"}, inputURI.Hostname()) {
-		return strutil.StrListContains(allowed, uri)
+		return strutil.StrListContainsCaseInsensitive(allowed, uri)
 	}
 
 	// otherwise, search for a match in a port-agnostic manner, per the OAuth RFC.

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -542,11 +542,11 @@ func isLocalAddr(hostname string) bool {
 	ip := net.ParseIP(hostname)
 	if ip != nil {
 		return ip.IsLoopback()
-	} else {
-		// localhost is not guaranteed to map back to a loopback interface address
-		// however, this is historically how the plugin has behaved
-		return hostname == "localhost"
 	}
+
+	// localhost is not guaranteed to map back to a loopback interface address
+	// however, this is historically how the plugin has behaved
+	return hostname == "localhost"
 }
 
 // validRedirect checks whether uri is in allowed using special handling for loopback uris.

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -157,13 +157,13 @@ func TestOIDC_AuthURL(t *testing.T) {
 				`scope=openid`,
 			}
 
-			for _, test := range expected {
-				matched, err := regexp.MatchString(test, authURL)
+			for _, testPattern := range expected {
+				matched, err := regexp.MatchString(testPattern, authURL)
 				if err != nil {
 					t.Fatal(err)
 				}
 				if !matched {
-					t.Fatalf("expected auth_url %q to match regex: %s", authURL, test)
+					t.Fatalf("expected auth_url %q to match regex: %s", authURL, testPattern)
 				}
 			}
 		}

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -1563,6 +1563,7 @@ func TestOIDC_ValidRedirect(t *testing.T) {
 		{"https://example.com/a/b/c", []string{"a", "b", "https://example.com/a/b/c"}, true},
 		{"https://localhost:9000", []string{"a", "b", "https://localhost:5000"}, true},
 		{"https://127.0.0.1:9000", []string{"a", "b", "https://127.0.0.1:5000"}, true},
+		{"https://127.0.0.2:9000", []string{"a", "b", "https://127.0.0.2:5000"}, true},
 		{"https://[::1]:9000", []string{"a", "b", "https://[::1]:5000"}, true},
 		{"https://[::1]:9000/x/y?r=42", []string{"a", "b", "https://[::1]:5000/x/y?r=42"}, true},
 		{"https://EXAMPLE.com:5000", []string{"a", "b", "https://example.com:5000"}, true},


### PR DESCRIPTION
# Overview
This PR proposes to make the redirecut URI matching validation case-insensitive.

### Background
An HVD user recently reported an issue where they could not log into the Vault UI using the OIDC auth method even when the URL was correct. 

```
"Error: Missing auth_url. Please check that allowed_redirect_uris for the role include this mount path."
```

This was discovered when a customer had named their HVD cluster with capital letters (e.g. ABC-cluster).  
When setting allowed_redirect_uris as a part of the [OIDC setup process](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth?in=vault%2Fauth-methods#get-auth0-credentials) and then attempting to login to the Vault UI, the browser automatically transforms the login URL to all-lowercase, causing the URL to not match the configured allowed_redirect_uris.

### Impact

This issue affects users whose clusters IDs have capital letters in them and are trying to login via OIDC in the Vault UI. 

# Tests
Confirmed that the new tests fail before the change was implemented

```
=== RUN   TestOIDC_AuthURL
=== RUN   TestOIDC_AuthURL/case_insensitive
=== PAUSE TestOIDC_AuthURL/case_insensitive
=== CONT  TestOIDC_AuthURL/case_insensitive
2024-03-12T15:48:16.578-0500 [WARN]  unauthorized redirect_uri: redirect_uri=https://EXAMPLE.com
    path_oidc_test.go:166: expected auth_url "" to match regex: client_id=abc
--- FAIL: TestOIDC_AuthURL (0.33s)
    --- FAIL: TestOIDC_AuthURL/case_insensitive (0.00s)
```

```
=== RUN   TestOIDC_ValidRedirect
    path_oidc_test.go:1582: Fail on https://EXAMPLE.com:5000/[a b https://example.com:5000]. Expected: true
--- FAIL: TestOIDC_ValidRedirect (0.00s)
```