### PR TITLE
Made OIDC auth renewable according to the refresh token

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -5,10 +5,12 @@ package jwtauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/hashicorp/cap/jwt"
+	"github.com/hashicorp/cap/oidc"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -217,6 +219,60 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	}
 	if role == nil {
 		return nil, fmt.Errorf("role %s does not exist during renewal", roleName)
+	}
+
+	if tokenString, ok := req.Auth.InternalData["token"]; ok {
+		var token oauth2.Token
+		err = json.Unmarshal(([]byte)(tokenString.(string)), &token)
+		if err != nil {
+			return nil, err
+		}
+		config, err := b.config(ctx, req.Storage)
+		if err != nil {
+			return nil, err
+		}
+		if config == nil {
+			return logical.ErrorResponse("Could not load configuration"), nil
+		}
+		provider, err := b.getProvider(config)
+		if err != nil {
+			return nil, fmt.Errorf("error getting provider for login operation: %w", err)
+		}
+		discovery, err := provider.DiscoveryInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		pctx, err := provider.HTTPClientContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		oauth2Config := oauth2.Config{
+			ClientID:     config.OIDCClientID,
+			ClientSecret: config.OIDCClientSecret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  discovery.AuthURL,
+				TokenURL: discovery.TokenURL,
+			},
+		}
+		ts := oauth2Config.TokenSource(pctx, &token)
+
+		// do a quick check to make sure we can get a fresh token
+		newToken, err := ts.Token()
+		if err != nil {
+			return nil, err
+		}
+		if newToken == nil {
+			return nil, errors.New("failed to retrieve new access token from refresh")
+		}
+
+		// if we have a fresh identity token then use it to get a fresh identity
+		if idToken, ok := newToken.Extra("id_token").(string); ok {
+			tk, err := oidc.NewToken(oidc.IDToken(idToken), newToken)
+			if err != nil {
+				return nil, err
+			}
+			return b.oidcEstablish(ctx, provider, roleName, role, tk, oidc.IDToken(idToken))
+		}
 	}
 
 	resp := &logical.Response{Auth: req.Auth}


### PR DESCRIPTION
# Overview

This makes it so that security teams that rely on their identity provider to decide when a user continues to be valid and have access (such as during user off boarding) won't have to manually invalidate a user's credentials in vault as well. This makes adoption much easier and automates important security steps. 

# Design of Change

We simply add a step that saves the access token, refresh token, and expiry info into the internal metadata for a token. Then during a renew we check these values and use the oauth2 library directly to refresh the value (this feature isn't supported in the hashicorp oidc library and that library was too confusing for me to go and make a seemless change there). I also reused much of the code that serves the callback endpoint so that we get to update the user identity/groups every time we successfully refresh.

# Related Issues/Pull Requests

N/A 

# Contributor Checklist

Docs have not been added yet since I want to get a review of this change done first. Please direct me to where I can include appropriate CI tests. 
