### PR TITLE
chore: remove unused validateAudience function

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -5,13 +5,11 @@ package jwtauth
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/mitchellh/pointerstructure"
 	"github.com/ryanuber/go-glob"
 )
@@ -87,26 +85,6 @@ func extractMetadata(logger log.Logger, allClaims map[string]interface{}, claimM
 		}
 	}
 	return metadata, nil
-}
-
-// validateAudience checks whether any of the audiences in audClaim match those
-// in boundAudiences. If strict is true and there are no bound audiences, then the
-// presence of any audience in the received claim is considered an error.
-func validateAudience(boundAudiences, audClaim []string, strict bool) error {
-	if strict && len(boundAudiences) == 0 && len(audClaim) > 0 {
-		return errors.New("audience claim found in JWT but no audiences bound to the role")
-	}
-
-	if len(boundAudiences) > 0 {
-		for _, v := range boundAudiences {
-			if strutil.StrListContains(audClaim, v) {
-				return nil
-			}
-		}
-		return errors.New("aud claim does not match any bound audience")
-	}
-
-	return nil
 }
 
 // validateBoundClaims checks that all of the claim:value requirements in boundClaims are

--- a/claims_test.go
+++ b/claims_test.go
@@ -199,33 +199,6 @@ func TestExtractMetadata(t *testing.T) {
 	}
 }
 
-func TestValidateAudience(t *testing.T) {
-	tests := []struct {
-		boundAudiences []string
-		audience       []string
-		strict         bool
-		errExpected    bool
-	}{
-		{[]string{"a"}, []string{"a"}, false, false},
-		{[]string{"a"}, []string{"b"}, false, true},
-		{[]string{"a"}, []string{""}, false, true},
-		{[]string{}, []string{"a"}, false, false},
-		{[]string{}, []string{"a"}, true, true},
-		{[]string{"a", "b"}, []string{"a"}, false, false},
-		{[]string{"a", "b"}, []string{"b"}, false, false},
-		{[]string{"a", "b"}, []string{"a", "b", "c"}, false, false},
-		{[]string{"a", "b"}, []string{"c", "d"}, false, true},
-	}
-
-	for _, test := range tests {
-		err := validateAudience(test.boundAudiences, test.audience, test.strict)
-		if test.errExpected != (err != nil) {
-			t.Fatalf("unexpected error result: boundAudiences %v, audience %v, strict %t, err: %v",
-				test.boundAudiences, test.audience, test.strict, err)
-		}
-	}
-}
-
 func TestValidateBoundClaims(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
# Overview
Removes the unused `validateAudience` function

https://github.com/hashicorp/vault-plugin-auth-jwt/blob/a847fcbf231bee58dbd2c38d9b0c20890e74a9c0/claims.go#L92-L110

as the one in [`hashicorp/cap/jwt/jwt.go`](https://github.com/hashicorp/cap/blob/b85f9a71c328388b9bd1d506efa3479f8d22c5b7/jwt/jwt.go#L287-L302) is used instead, as part of

https://github.com/hashicorp/vault-plugin-auth-jwt/blob/a847fcbf231bee58dbd2c38d9b0c20890e74a9c0/path_login.go#L152-L156

# Design of Change
To not confuse those reading the source and expecting this repo's `validateAudience` to be in use.

# Contributor Checklist
~~[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet~~
~~[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)~~
[x] Backwards compatible
