### PR TITLE
Optionally Ignore trailing "/" at end of boundAudience

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -96,19 +96,19 @@ func pathRole(b *jwtAuthBackend) *framework.Path {
 			},
 			"expiration_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew. 
+				Description: `Duration in seconds of leeway when validating expiration of a token to account for clock skew.
 Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 				Default: claimDefaultLeeway,
 			},
 			"not_before_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew. 
+				Description: `Duration in seconds of leeway when validating not before values of a token to account for clock skew.
 Defaults to 150 (2.5 minutes) if set to 0 and can be disabled if set to -1.`,
 				Default: claimDefaultLeeway,
 			},
 			"clock_skew_leeway": {
 				Type: framework.TypeSignedDurationSecond,
-				Description: `Duration in seconds of leeway when validating all claims to account for clock skew. 
+				Description: `Duration in seconds of leeway when validating all claims to account for clock skew.
 Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 				Default: jwt.DefaultLeeway,
 			},
@@ -139,7 +139,7 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 			},
 			"user_claim_json_pointer": {
 				Type: framework.TypeBool,
-				Description: `If true, the user_claim value will use JSON pointer syntax 
+				Description: `If true, the user_claim value will use JSON pointer syntax
 for referencing claims.`,
 			},
 			"groups_claim": {
@@ -156,13 +156,13 @@ for referencing claims.`,
 			},
 			"verbose_oidc_logging": {
 				Type: framework.TypeBool,
-				Description: `Log received OIDC tokens and claims when debug-level logging is active. 
-Not recommended in production since sensitive information may be present 
+				Description: `Log received OIDC tokens and claims when debug-level logging is active.
+Not recommended in production since sensitive information may be present
 in OIDC responses.`,
 			},
 			"max_age": {
 				Type: framework.TypeDurationSecond,
-				Description: `Specifies the allowable elapsed time in seconds since the last time the 
+				Description: `Specifies the allowable elapsed time in seconds since the last time the
 user was actively authenticated.`,
 			},
 		},
@@ -278,6 +278,17 @@ func (b *jwtAuthBackend) role(ctx context.Context, s logical.Storage, name strin
 	if len(role.TokenBoundCIDRs) == 0 && len(role.BoundCIDRs) > 0 {
 		role.TokenBoundCIDRs = role.BoundCIDRs
 	}
+
+	boundAudiences := []string{}
+	for _, boundAudience := range role.BoundAudiences {
+		boundAudiences = append(boundAudiences, boundAudience)
+
+		if len(boundAudience) > 0 && boundAudience[len(boundAudience)-1] == '/' {
+			boundAudiences = append(boundAudiences, boundAudience[:len(boundAudience)-1])
+		}
+	}
+
+	role.BoundAudiences = boundAudiences
 
 	return role, nil
 }

--- a/path_role.go
+++ b/path_role.go
@@ -464,20 +464,22 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 
 	// disregard the trailing slash (if it exists) on all bound audiences if the flag is set
 	if _, ok := data.GetOk("bound_audience_disregard_trailing_slash"); ok {
-		audiencesWithoutTrailingSlash := make([]string, len(role.BoundAudiences))
-		processed := make(map[string]bool) // used to avoid duplicate entries
+		boundAudiences := []string{}
+		processed := map[string]bool{} // used to prevent duplicate entries
 
 		for _, audience := range role.BoundAudiences {
 			// trim the trailing slash from the audience if it exists
 			audienceWithoutTrailingSlash := strings.TrimRight(audience, "/")
 
+			// add the audience to the list of bound audiences if the audience
+			// without the trailing slash has not already been processed
 			if _, ok := processed[audienceWithoutTrailingSlash]; !ok {
-				audiencesWithoutTrailingSlash = append(audiencesWithoutTrailingSlash, audienceWithoutTrailingSlash)
+				boundAudiences = append(boundAudiences, audienceWithoutTrailingSlash)
 				processed[audienceWithoutTrailingSlash] = true
 			}
 		}
 
-		role.BoundAudiences = audiencesWithoutTrailingSlash
+		role.BoundAudiences = boundAudiences
 	}
 
 	if boundSubject, ok := data.GetOk("bound_subject"); ok {

--- a/path_role.go
+++ b/path_role.go
@@ -124,8 +124,7 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 				Type: framework.TypeString,
 				Description: `Policy for handling trailing slashes in bound_audiences. Allowed values are "add" and "remove":
 				"add": Ensures each audience in bound_audiences is included both with and without a trailing slash, if the audience does not already have one.
-				"remove": Ensures each audience in bound_audiences is included both with and without a trailing slash, if it the audience has one already.
-				`,
+				"remove": Ensures each audience in bound_audiences is included both with and without a trailing slash, if it the audience has one already.`,
 			},
 			"bound_claims_type": {
 				Type:        framework.TypeString,

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -6,7 +6,6 @@ package jwtauth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -518,10 +517,9 @@ func TestPath_Create(t *testing.T) {
 		}
 	})
 
-	t.Run("duplicate audiences are not included", func(t *testing.T) {
+	t.Run("audiences have trailing slash removed if exists", func(t *testing.T) {
 		b, storage := getBackend(t)
-		originalAudiences := []string{"audience-1/", "audience-1", "audience-3/"}
-		// expectedAudiences := []string{"audience-1", "audience-3"}
+		originalAudiences := []string{"audience-1/", "audience-2/", "audience-3"}
 
 		data := map[string]interface{}{
 			"role_type":       "jwt",
@@ -533,7 +531,7 @@ func TestPath_Create(t *testing.T) {
 
 		req := &logical.Request{
 			Operation: logical.CreateOperation,
-			Path:      "role/test17",
+			Path:      "role/test13",
 			Storage:   storage,
 			Data:      data,
 		}
@@ -546,14 +544,54 @@ func TestPath_Create(t *testing.T) {
 			t.Fatalf("did not expect error")
 		}
 
-		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test17")
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test13")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// fmt.Println(len(role.BoundAudiences))
-		for i, audience := range role.BoundAudiences {
-			fmt.Println(i, audience)
+		// compare the expected audiences with the actual result
+		expectedAudiences := []string{"audience-1", "audience-2", "audience-3"}
+		if !reflect.DeepEqual(role.BoundAudiences, expectedAudiences) {
+			t.Fatalf("expected audiences: %v, got: %v", expectedAudiences, role.BoundAudiences)
+		}
+	})
+
+	t.Run("duplicate audiences are not included", func(t *testing.T) {
+		b, storage := getBackend(t)
+		originalAudiences := []string{"audience-1/", "audience-1", "audience-3/"}
+
+		data := map[string]interface{}{
+			"role_type":       "jwt",
+			"user_claim":      "user",
+			"policies":        "test",
+			"bound_audiences": strings.Join(originalAudiences, ", "),
+			"bound_audience_disregard_trailing_slash": true,
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/test14",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != nil && resp.IsError() {
+			t.Fatalf("did not expect error")
+		}
+
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test14")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// compare the expected audiences with the actual result
+		expectedAudiences := []string{"audience-1", "audience-3"}
+		if !reflect.DeepEqual(role.BoundAudiences, expectedAudiences) {
+			t.Fatalf("expected audiences: %v, got: %v", expectedAudiences, role.BoundAudiences)
 		}
 	})
 }

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -218,42 +218,6 @@ func TestPath_Create(t *testing.T) {
 		}
 	})
 
-	t.Run("appends audience with trailing slash", func(t *testing.T) {
-		b, storage := getBackend(t)
-		// Test has audience
-		data := map[string]interface{}{
-			"role_type":                            "jwt",
-			"user_claim":                           "user",
-			"policies":                             "test",
-			"bound_audiences":                      "vault",
-			"bound_audience_trailing_slash_policy": "add",
-		}
-
-		req := &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      "role/tes",
-			Storage:   storage,
-			Data:      data,
-		}
-
-		resp, err := b.HandleRequest(context.Background(), req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp != nil && resp.IsError() {
-			t.Fatalf("did not expect error")
-		}
-
-		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "tes")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(role.BoundAudiences) != 2 {
-			t.Fatalf("expected 2 audiences, got %d", len(role.BoundAudiences))
-		}
-	})
-
 	t.Run("has cidr", func(t *testing.T) {
 		b, storage := getBackend(t)
 		// Test has cidr
@@ -550,6 +514,145 @@ func TestPath_Create(t *testing.T) {
 		}
 		if resp.Error().Error() != "claim is not a string: 10" {
 			t.Fatalf("unexpected err: %v", resp)
+		}
+	})
+
+	t.Run("audience and audience with trailing slash included through add option", func(t *testing.T) {
+		b, storage := getBackend(t)
+		originalAudiences := []string{"audience-1", "audience-2", "audience-3"}
+
+		expectedAudiences := map[string]bool{}
+		for _, audience := range originalAudiences {
+			expectedAudiences[audience] = false
+			expectedAudiences[audience+"/"] = false
+		}
+
+		data := map[string]interface{}{
+			"role_type":                            "jwt",
+			"user_claim":                           "user",
+			"policies":                             "test",
+			"bound_audiences":                      strings.Join(originalAudiences, ", "),
+			"bound_audience_trailing_slash_policy": "add",
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/test13",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != nil && resp.IsError() {
+			t.Fatalf("did not expect error")
+		}
+
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test13")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, audience := range role.BoundAudiences {
+			if _, ok := expectedAudiences[audience]; !ok {
+				t.Fatalf("unexpected audience: %s", audience)
+			}
+			expectedAudiences[audience] = true
+		}
+
+		for audience, included := range expectedAudiences {
+			if !included {
+				t.Fatalf("expected audience not included: %s", audience)
+			}
+		}
+	})
+
+	t.Run("audience and audience with trailing slash included through remove option", func(t *testing.T) {
+		b, storage := getBackend(t)
+		originalAudiences := []string{"audience-1/", "audience-2/", "audience-3/"}
+
+		expectedAudiences := map[string]bool{}
+		for _, audience := range originalAudiences {
+			expectedAudiences[audience] = false
+			expectedAudiences[audience[:len(audience)-1]] = false
+		}
+
+		data := map[string]interface{}{
+			"role_type":                            "jwt",
+			"user_claim":                           "user",
+			"policies":                             "test",
+			"bound_audiences":                      strings.Join(originalAudiences, ", "),
+			"bound_audience_trailing_slash_policy": "remove",
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/test14",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != nil && resp.IsError() {
+			t.Fatalf("did not expect error")
+		}
+
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test14")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, audience := range role.BoundAudiences {
+			if _, ok := expectedAudiences[audience]; !ok {
+				t.Fatalf("unexpected audience: %s", audience)
+			}
+			expectedAudiences[audience] = true
+		}
+
+		for audience, included := range expectedAudiences {
+			if !included {
+				t.Fatalf("expected audience not included: %s", audience)
+			}
+		}
+	})
+
+	t.Run("duplicate audience is not included", func(t *testing.T) {
+		b, storage := getBackend(t)
+		data := map[string]interface{}{
+			"role_type":                            "jwt",
+			"user_claim":                           "user",
+			"policies":                             "test",
+			"bound_audiences":                      "audience-1, audience-1, audience-2",
+			"bound_audience_trailing_slash_policy": "add",
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/test13",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != nil && resp.IsError() {
+			t.Fatalf("did not expect error")
+		}
+
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "test13")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(role.BoundAudiences) != 4 {
+			t.Fatalf("expected 2 audiences, got %d", len(role.BoundAudiences))
 		}
 	})
 }

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -218,6 +218,42 @@ func TestPath_Create(t *testing.T) {
 		}
 	})
 
+	t.Run("appends audience with trailing slash", func(t *testing.T) {
+		b, storage := getBackend(t)
+		// Test has audience
+		data := map[string]interface{}{
+			"role_type":                            "jwt",
+			"user_claim":                           "user",
+			"policies":                             "test",
+			"bound_audiences":                      "vault",
+			"bound_audience_trailing_slash_policy": "add",
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/tes",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != nil && resp.IsError() {
+			t.Fatalf("did not expect error")
+		}
+
+		role, err := b.(*jwtAuthBackend).role(context.Background(), storage, "tes")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(role.BoundAudiences) != 2 {
+			t.Fatalf("expected 2 audiences, got %d", len(role.BoundAudiences))
+		}
+	})
+
 	t.Run("has cidr", func(t *testing.T) {
 		b, storage := getBackend(t)
 		// Test has cidr


### PR DESCRIPTION
# Overview
This PR allows users to optionally ignore the trailing slash at the end of each bound audience (if the trailing slash exists) by setting the `bound_audience_disregard_trailing_slash` flag to `true`. The PR also prevents duplicate bound_audiences from being entered, where the only difference would be the trailing slash (ie adding `https://testing.com` and `https://testing.com/` to the `bound_audiences` field results in `https://testing.com` being the only one added when the flag is in place. The default behavior remains in place if the flag is not set to true.

# Testing

* Created API on Auth0 with audience of `https://testing.com`

### Use without trailing slash and without flag (shows that default behavior works normally)

* Enable JWT in Vault

```vault auth enable jwt```

* Config JWT

```
vault write auth/jwt/config \
    oidc_discovery_url="https://MY_DOMAIN.us.auth0.com/" \
    oidc_client_id="" \
    oidc_client_secret="" \
    default_role="demo"
```

* Create Role on Vault

```
vault write auth/jwt/role/my-role \
    role_type="jwt" \
    user_claim="sub" \
    bound_audiences='https://testing.com' \
     policies="default"
```

* Read role from vault

```
vault read auth/jwt/role/my-role
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            [https://testing.com]
bound_claims               <nil>
bound_claims_type          string
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
max_age                    0
not_before_leeway          0
oidc_scopes                <nil>
policies                   [default]
role_type                  jwt
token_bound_cidrs          []
token_explicit_max_ttl     0s
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [default]
token_ttl                  0s
token_type                 default
user_claim                 sub
user_claim_json_pointer    false
verbose_oidc_logging       false
```

* Retrieve JWT Token from Auth0

```
curl --request POST \
  --url 'https://MY_DOMAIN.us.auth0.com/oauth/token' \
  --header 'content-type: application/json' \
  --data '{
    "client_id": "AUTH0_CLIENT_ID",
    "client_secret": "AUTH0_CLIENT_SECRET",
    "audience": "https://testing.com",
    "grant_type": "client_credentials"
  }'
```

* Successful authentication into Vault with the given jwt token from Auth0

```
vault write auth/jwt/login role="my-role" jwt="$JWT_TOKEN"

Key                  Value
---                  -----
token                TOKEN
token_accessor       TOKEN_ACCESSOR
token_duration       768h
token_renewable      true
token_policies       ["default"]
identity_policies    []
policies             ["default"]
token_meta_role      my-role
```

### Use with trailing slash with flag turned on

* Create role with trailing slash and flag activated

```
vault write auth/jwt/role/my-role \
    role_type="jwt" \
    user_claim="sub" \
    bound_audiences='https://testing.com/' \
    bound_audience_disregard_trailing_slash=true \
     policies="default"
```

* Read role to confirm that it was created without the trailing slash

```
vault read auth/jwt/role/my-role
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            [https://testing.com]
bound_claims               <nil>
bound_claims_type          string
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
max_age                    0
not_before_leeway          0
oidc_scopes                <nil>
policies                   [default]
role_type                  jwt
token_bound_cidrs          []
token_explicit_max_ttl     0s
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [default]
token_ttl                  0s
token_type                 default
user_claim                 sub
user_claim_json_pointer    false
verbose_oidc_logging       false
```


* Retrieve JWT Token from Auth0

```
curl --request POST \
  --url 'https://MY_DOMAIN.us.auth0.com/oauth/token' \
  --header 'content-type: application/json' \
  --data '{
    "client_id": "AUTH0_CLIENT_ID",
    "client_secret": "AUTH0_CLIENT_SECRET",
    "audience": "https://testing.com",
    "grant_type": "client_credentials"
  }'
```

* Successful authentication into Vault with the given jwt token from Auth0

```
vault write auth/jwt/login role="my-role" jwt="$JWT_TOKEN"

Key                  Value
---                  -----
token                TOKEN
token_accessor       TOKEN_ACCESSOR
token_duration       768h
token_renewable      true
token_policies       ["default"]
identity_policies    []
policies             ["default"]
token_meta_role      my-role
```

### Adding the trailing slash without the flag turned on results in an error

* Add the role to Vault with the trailing slash in bound_audiences and the flag off

```
vault write auth/jwt/role/my-role \
    role_type="jwt" \
    user_claim="sub" \
    bound_audiences='https://testing.com/' \
     policies="default"
```

* Authenticating results in an error

```
Error writing data to auth/jwt/login: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/jwt/login
Code: 400. Errors:

* error validating token: invalid audience (aud) claim: audience claim does not match any expected audience
```

### Confirmed that duplicates aren't added when flag is turned on

* Write to role
```
vault write auth/jwt/role/my-role \
    role_type="jwt" \
    user_claim="sub" \
    bound_audiences='https://testing.com/, https://testing.com'  \
    bound_audience_disregard_trailing_slash=true \
     policies="default"
```

* Read role to confirm that duplicate wasn't added

```
vault read auth/jwt/role/my-role
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            [https://testing.com]
bound_claims               <nil>
bound_claims_type          string
bound_subject              n/a                                                                     claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
max_age                    0
```

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
