### PR TITLE
Update CHANGELOG for VAULT-33101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,22 +22,6 @@ IMPROVEMENTS:
 
 * Updated dependencies (https://github.com/hashicorp/vault-plugin-auth-jwt/pull/317)
 
-## v0.22.1
-
-FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
-IMPROVEMENTS:
-* Updated dependencies
-  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
-  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
-  * `golang.org/x/oauth2` v0.23.0 -> v0.28.0
-  * `golang.org/x/sync` v0.8.0 -> v0.12.0
-  * `golang.org/x/crypto` v0.27.0 -> v0.36.0
-  * `golang.org/x/net` v0.29.0 -> v0.38.0
-  * `golang.org/x/sys` v0.25.0 -> v0.31.0
-  * `golang.org/x/text` v0.18.0 -> v0.23.0
-
 ## v0.22.0
 
 IMPROVEMENTS:
@@ -52,25 +36,6 @@ IMPROVEMENTS:
 ## v0.21.0
 
 NO CHANGES
-
-## v0.20.4
-
-FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
-IMPROVEMENTS:
-* Updated dependencies:
-  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
-  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
-  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
-  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
-  * `golang.org/x/sync` v0.7.0 -> v0.12.0
-  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
-  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
-  * `golang.org/x/net` v0.27.0 -> v0.38.0
-  * `golang.org/x/sys` v0.22.0 -> v0.31.0
-  * `golang.org/x/text` v0.16.0 -> v0.23.0
-
 
 ## v0.20.3
 
@@ -104,23 +69,6 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.15.0 -> v0.17.0
   * `golang.org/x/sync` v0.5.0 -> v0.6.0
   * `google.golang.org/api` v0.154.0 -> v0.163.0
-
-## v0.19.1
-
-FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
-IMPROVEMENTS:
-* Updated dependencies:
-  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
-  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
-  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
-  * `golang.org/x/sync` v0.7.0 -> v0.12.0
-  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
-  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
-  * `golang.org/x/net` v0.27.0 -> v0.38.0
-  * `golang.org/x/sys` v0.22.0 -> v0.31.0
-  * `golang.org/x/text` v0.16.0 -> v0.23.0
 
 ## v0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,42 @@
 ## Unreleased
 
+## v0.23.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `golang.org/x/oauth2` v0.25.0 -> v0.28.0
+  * `golang.org/x/sync` v0.10.0 -> v0.12.0
+  * `golang.org/x/crypto` v0.32.0 -> v0.36.0
+ 	* `golang.org/x/net` v0.34.0 -> v0.38.0
+	* `golang.org/x/sys` v0.29.0 -> v0.31.0
+	* `golang.org/x/text` v0.21.0 -> v0.23.0
+
 ## v0.23.0
 
 IMPROVEMENTS:
 
 * Updated dependencies (https://github.com/hashicorp/vault-plugin-auth-jwt/pull/317)
+
+## v0.22.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `golang.org/x/oauth2` v0.23.0 -> v0.28.0
+  * `golang.org/x/sync` v0.8.0 -> v0.12.0
+  * `golang.org/x/crypto` v0.27.0 -> v0.36.0
+  * `golang.org/x/net` v0.29.0 -> v0.38.0
+  * `golang.org/x/sys` v0.25.0 -> v0.31.0
+  * `golang.org/x/text` v0.18.0 -> v0.23.0
 
 ## v0.22.0
 
@@ -20,6 +52,25 @@ IMPROVEMENTS:
 ## v0.21.0
 
 NO CHANGES
+
+## v0.20.4
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies:
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
+  * `golang.org/x/sync` v0.7.0 -> v0.12.0
+  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
+  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
+  * `golang.org/x/net` v0.27.0 -> v0.38.0
+  * `golang.org/x/sys` v0.22.0 -> v0.31.0
+  * `golang.org/x/text` v0.16.0 -> v0.23.0
+
 
 ## v0.20.3
 
@@ -53,6 +104,23 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.15.0 -> v0.17.0
   * `golang.org/x/sync` v0.5.0 -> v0.6.0
   * `google.golang.org/api` v0.154.0 -> v0.163.0
+
+## v0.19.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies:
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
+  * `golang.org/x/sync` v0.7.0 -> v0.12.0
+  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
+  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
+  * `golang.org/x/net` v0.27.0 -> v0.38.0
+  * `golang.org/x/sys` v0.22.0 -> v0.31.0
+  * `golang.org/x/text` v0.16.0 -> v0.23.0
 
 ## v0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.25.0 -> v0.28.0
   * `golang.org/x/sync` v0.10.0 -> v0.12.0
   * `golang.org/x/crypto` v0.32.0 -> v0.36.0
- 	* `golang.org/x/net` v0.34.0 -> v0.38.0
-	* `golang.org/x/sys` v0.29.0 -> v0.31.0
+  * `golang.org/x/net` v0.34.0 -> v0.38.0
+  * `golang.org/x/sys` v0.29.0 -> v0.31.0
 	* `golang.org/x/text` v0.21.0 -> v0.23.0
 
 ## v0.23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ IMPROVEMENTS:
   * `golang.org/x/crypto` v0.32.0 -> v0.36.0
   * `golang.org/x/net` v0.34.0 -> v0.38.0
   * `golang.org/x/sys` v0.29.0 -> v0.31.0
-	* `golang.org/x/text` v0.21.0 -> v0.23.0
+  * `golang.org/x/text` v0.21.0 -> v0.23.0
 
 ## v0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.23.1
 
 FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 IMPROVEMENTS:
 * Updated dependencies

--- a/path_role.go
+++ b/path_role.go
@@ -120,7 +120,7 @@ Defaults to 60 (1 minute) if set to 0 and can be disabled if set to -1.`,
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of 'aud' claims that are valid for login; any match is sufficient`,
 			},
-			"bound_audience_disregard_trailing_slash": {
+			"normalize_bound_audiences": {
 				Type:        framework.TypeBool,
 				Description: `If true, ignores the trailing slash in each bound audience when matching the audience claim in the token.`,
 			},
@@ -463,19 +463,23 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 	}
 
 	// disregard the trailing slash (if it exists) on all bound audiences if the flag is set
-	if _, ok := data.GetOk("bound_audience_disregard_trailing_slash"); ok {
+	if _, ok := data.GetOk("normalize_bound_audiences"); ok {
 		boundAudiences := []string{}
 		processed := map[string]bool{} // used to prevent duplicate entries
 
 		for _, audience := range role.BoundAudiences {
+			normalizedAudience := audience
+
 			// trim the trailing slash from the audience if it exists
-			audienceWithoutTrailingSlash := strings.TrimRight(audience, "/")
+			if strings.HasSuffix(normalizedAudience, "/") {
+				normalizedAudience = normalizedAudience[:len(normalizedAudience)-1]
+			}
 
 			// add the audience to the list of bound audiences if the audience
 			// without the trailing slash has not already been processed
-			if _, ok := processed[audienceWithoutTrailingSlash]; !ok {
-				boundAudiences = append(boundAudiences, audienceWithoutTrailingSlash)
-				processed[audienceWithoutTrailingSlash] = true
+			if _, ok := processed[normalizedAudience]; !ok {
+				boundAudiences = append(boundAudiences, normalizedAudience)
+				processed[normalizedAudience] = true
 			}
 		}
 

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -522,11 +522,11 @@ func TestPath_Create(t *testing.T) {
 		originalAudiences := []string{"audience-1/", "audience-2/", "audience-3"}
 
 		data := map[string]interface{}{
-			"role_type":       "jwt",
-			"user_claim":      "user",
-			"policies":        "test",
-			"bound_audiences": strings.Join(originalAudiences, ", "),
-			"bound_audience_disregard_trailing_slash": true,
+			"role_type":                 "jwt",
+			"user_claim":                "user",
+			"policies":                  "test",
+			"bound_audiences":           strings.Join(originalAudiences, ", "),
+			"normalize_bound_audiences": true,
 		}
 
 		req := &logical.Request{
@@ -561,11 +561,11 @@ func TestPath_Create(t *testing.T) {
 		originalAudiences := []string{"audience-1/", "audience-1", "audience-3/"}
 
 		data := map[string]interface{}{
-			"role_type":       "jwt",
-			"user_claim":      "user",
-			"policies":        "test",
-			"bound_audiences": strings.Join(originalAudiences, ", "),
-			"bound_audience_disregard_trailing_slash": true,
+			"role_type":                 "jwt",
+			"user_claim":                "user",
+			"policies":                  "test",
+			"bound_audiences":           strings.Join(originalAudiences, ", "),
+			"normalize_bound_audiences": true,
 		}
 
 		req := &logical.Request{


### PR DESCRIPTION
Updates the changelog to account for the change made in this [PR](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/323/). Also adds backport versions.