### PR TITLE
allow optional access token to be used to fetch additional groups

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -34,6 +34,10 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "The signed JWT to validate.",
 			},
+			"ms_graph_access_token": {
+				Type:        framework.TypeString,
+				Description: "An optional token used to fetch group memberships specified by the claim source in the jwt",
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -112,6 +116,8 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return logical.ErrorResponse("missing token"), nil
 	}
 
+	msGraphAccessToken := d.Get("ms_graph_access_token").(string)
+
 	if len(role.TokenBoundCIDRs) > 0 {
 		if req.Connection == nil {
 			b.Logger().Warn("token bound CIDRs found but no connection information available for validation")
@@ -172,8 +178,7 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 			}
 		}
 	}
-
-	alias, groupAliases, err := b.createIdentity(ctx, allClaims, roleName, role, nil)
+	alias, groupAliases, err := b.createIdentity(ctx, allClaims, roleName, role, &accessTokenSrc{accessToken: msGraphAccessToken})
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
@@ -350,3 +355,15 @@ const (
 Authenticates JWTs.
 `
 )
+
+type accessTokenSrc struct {
+	accessToken string
+}
+
+func (j *accessTokenSrc) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{
+		AccessToken: j.accessToken,
+		TokenType:   "Bearer",
+	}, nil
+
+}


### PR DESCRIPTION
this allows an optional access token , `ms_graph_access_token`, to be specified while logging in using the JWT auth backend. This token will only be used with the azure provider and is used to fetch additional groups from the Microsoft Graph API

Testing:

was able to successfully login and retrieve group memberships as indicated by the policies attached to the token. these policies were attached to group-alias's corresponding to the Microsoft group IDs that were pulled with the access token

```
vault write auth/jwt/login jwt=$ID_TOKEN ms_graph_access_token=$ACCESS_TOKEN
Key                  Value
---                  -----
token                {}
token_accessor       {}
token_duration       768h
token_renewable      true
token_policies       ["default"]
identity_policies    ["test-policy1" "test-policy2"]
policies             ["default" "test-policy1" "test-policy2"]
token_meta_role      test-entra-jwt
```