### PR TITLE
Update CHANGELOG for VAULT-33101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## v0.23.1
 
-FEATURES:
+IMPROVEMENTS:
   * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
-IMPROVEMENTS:
 * Updated dependencies
   * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
   * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,42 @@
 ## Unreleased
 
+## v0.23.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `golang.org/x/oauth2` v0.25.0 -> v0.28.0
+  * `golang.org/x/sync` v0.10.0 -> v0.12.0
+  * `golang.org/x/crypto` v0.32.0 -> v0.36.0
+ 	* `golang.org/x/net` v0.34.0 -> v0.38.0
+	* `golang.org/x/sys` v0.29.0 -> v0.31.0
+	* `golang.org/x/text` v0.21.0 -> v0.23.0
+
 ## v0.23.0
 
 IMPROVEMENTS:
 
 * Updated dependencies (https://github.com/hashicorp/vault-plugin-auth-jwt/pull/317)
+
+## v0.22.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `golang.org/x/oauth2` v0.23.0 -> v0.28.0
+  * `golang.org/x/sync` v0.8.0 -> v0.12.0
+  * `golang.org/x/crypto` v0.27.0 -> v0.36.0
+  * `golang.org/x/net` v0.29.0 -> v0.38.0
+  * `golang.org/x/sys` v0.25.0 -> v0.31.0
+  * `golang.org/x/text` v0.18.0 -> v0.23.0
 
 ## v0.22.0
 
@@ -20,6 +52,25 @@ IMPROVEMENTS:
 ## v0.21.0
 
 NO CHANGES
+
+## v0.20.4
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies:
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
+  * `golang.org/x/sync` v0.7.0 -> v0.12.0
+  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
+  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
+  * `golang.org/x/net` v0.27.0 -> v0.38.0
+  * `golang.org/x/sys` v0.22.0 -> v0.31.0
+  * `golang.org/x/text` v0.16.0 -> v0.23.0
+
 
 ## v0.20.3
 
@@ -53,6 +104,23 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.15.0 -> v0.17.0
   * `golang.org/x/sync` v0.5.0 -> v0.6.0
   * `google.golang.org/api` v0.154.0 -> v0.163.0
+
+## v0.19.1
+
+FEATURES:
+  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+IMPROVEMENTS:
+* Updated dependencies:
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
+  * `golang.org/x/sync` v0.7.0 -> v0.12.0
+  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
+  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
+  * `golang.org/x/net` v0.27.0 -> v0.38.0
+  * `golang.org/x/sys` v0.22.0 -> v0.31.0
+  * `golang.org/x/text` v0.16.0 -> v0.23.0
 
 ## v0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ IMPROVEMENTS:
    * `google.golang.org/api` v0.163.0 -> v0.197.0
 
 ## v0.21.1
+
 IMPROVEMENTS:
 * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.23.1
 
 FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 IMPROVEMENTS:
 * Updated dependencies
@@ -12,9 +12,9 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.25.0 -> v0.28.0
   * `golang.org/x/sync` v0.10.0 -> v0.12.0
   * `golang.org/x/crypto` v0.32.0 -> v0.36.0
- 	* `golang.org/x/net` v0.34.0 -> v0.38.0
-	* `golang.org/x/sys` v0.29.0 -> v0.31.0
-	* `golang.org/x/text` v0.21.0 -> v0.23.0
+  * `golang.org/x/net` v0.34.0 -> v0.38.0
+  * `golang.org/x/sys` v0.29.0 -> v0.31.0
+  * `golang.org/x/text` v0.21.0 -> v0.23.0
 
 ## v0.23.0
 
@@ -25,7 +25,7 @@ IMPROVEMENTS:
 ## v0.22.1
 
 FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 IMPROVEMENTS:
 * Updated dependencies
@@ -56,7 +56,7 @@ NO CHANGES
 ## v0.20.4
 
 FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 IMPROVEMENTS:
 * Updated dependencies:
@@ -108,7 +108,7 @@ IMPROVEMENTS:
 ## v0.19.1
 
 FEATURES:
-  * Added `bound_audience_disregard_trailing_slash` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 IMPROVEMENTS:
 * Updated dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.23.1
 
 IMPROVEMENTS:
-  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
 
 * Updated dependencies
   * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
@@ -23,10 +23,9 @@ IMPROVEMENTS:
 
 ## v0.22.1
 
-FEATURES:
-  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
 IMPROVEMENTS:
+* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
 * Updated dependencies
   * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
   * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
@@ -54,10 +53,9 @@ NO CHANGES
 
 ## v0.20.4
 
-FEATURES:
-  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
 IMPROVEMENTS:
+* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
 * Updated dependencies:
   * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
   * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
@@ -106,10 +104,9 @@ IMPROVEMENTS:
 
 ## v0.19.1
 
-FEATURES:
-  * Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
 IMPROVEMENTS:
+* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
 * Updated dependencies:
   * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
   * `github.com/stretchr/testify` v1.9.0 -> v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ IMPROVEMENTS:
    * `golang.org/x/sync` v0.7.0 -> v0.8.0
    * `google.golang.org/api` v0.163.0 -> v0.197.0
 
+## v0.21.1
+IMPROVEMENTS:
+* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
+
+* Updated dependencies:
+  * `github.com/go-jose/go-jose/v3` v3.0.3 -> v3.0.4
+  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
+  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
+  * `golang.org/x/sync` v0.7.0 -> v0.12.0
+  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
+  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
+  * `golang.org/x/net` v0.27.0 -> v0.38.0
+  * `golang.org/x/sys` v0.22.0 -> v0.31.0
+  * `golang.org/x/text` v0.16.0 -> v0.23.0
+
 ## v0.21.0
 
 NO CHANGES
@@ -101,22 +117,6 @@ IMPROVEMENTS:
   * `golang.org/x/oauth2` v0.15.0 -> v0.17.0
   * `golang.org/x/sync` v0.5.0 -> v0.6.0
   * `google.golang.org/api` v0.154.0 -> v0.163.0
-
-## v0.19.1
-
-IMPROVEMENTS:
-* Added `normalize_bound_audiences` as a flag that can be enabled to ignore the trailing slash at the end of each bound audience. Bound audiences that differ by only a trailing slash are treated as equivalent. This feature is set to `false` by default.
-
-* Updated dependencies:
-  * `github.com/go-jose/go-jose/v4` v4.0.4 -> v4.0.5
-  * `github.com/stretchr/testify` v1.9.0 -> v1.10.0
-  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
-  * `golang.org/x/sync` v0.7.0 -> v0.12.0
-  * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
-  * `golang.org/x/crypto` v0.25.0 -> v0.36.0
-  * `golang.org/x/net` v0.27.0 -> v0.38.0
-  * `golang.org/x/sys` v0.22.0 -> v0.31.0
-  * `golang.org/x/text` v0.16.0 -> v0.23.0
 
 ## v0.19.0
 


### PR DESCRIPTION
Updates the changelog to account for the change made in this [PR](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/323/). 