### PR TITLE
set go.mod to 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.24.1
+### Jun 05, 2025
+
+IMPROVEMENTS:
+* set go version in go.mod to same as [Vault](https://github.com/hashicorp/vault) 
+ 
 ## 0.24.0
 ### Jun 03, 2025
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/vault-plugin-auth-jwt
 
-go 1.24.2
+go 1.24
 
 require (
 	github.com/go-jose/go-jose/v3 v3.0.4


### PR DESCRIPTION
update go mod to 1.24. this is so the go version in go.mod is the same as Vault's

Stage for 0.24.1 release for this update to go.mod