### PR TITLE
fix: oidc public client without need to provide secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Successfully enabled 'jwt' at 'jwt'!
 
 To see all the supported paths, see the [JWT auth backend docs](https://developer.hashicorp.com/vault/docs/auth/jwt).
 
+### OIDC Public Client Support
+
+This plugin supports OIDC authentication for public clients using PKCE flow without requiring a client secret. Configure by providing only `oidc_discovery_url` and `oidc_client_id`:
+
+```sh
+$ vault write auth/jwt/config \
+    oidc_discovery_url="https://your-provider.com" \
+    oidc_client_id="your-client-id"
+```
+
 ## Developing
 
 If you wish to work on this plugin, you'll first need
@@ -156,7 +166,7 @@ Additionally, there are some BATs tests in the `tests` dir.
 - [Configure an OIDC provider](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers)
 - Save and export the following values to your shell:
   - `CLIENT_ID`
-  - `CLIENT_SECRET`
+  - `CLIENT_SECRET` (optional for public clients)
   - `ISSUER`
 - Export `VAULT_IMAGE` to test the image of your choice or place a vault binary
   in the `tests` directory.


### PR DESCRIPTION
# Overview
## Who the change affects or is for?
This change affects developers and organizations using OIDC authentication with Vault who need to support public client applications.

## What is the change?
Fix OIDC authentication when PKCE without requiring a client secret. Users can now configure OIDC authentication by providing only `oidc_discovery_url` and `oidc_client_id`, with `oidc_client_secret` being optional.

## Why is the change needed?
Public client applications (as defined in OAuth 2.0 RFC) cannot securely store client secrets since they run on end-user devices. Modern OAuth providers support PKCE as a secure alternative to client secrets for these scenarios. This change enables Vault to work with public OIDC clients, enhancing its flexibility and usability in diverse application environments.

## How does this change affect the user experience?
Users can now configure OIDC authentication without requiring a client secret:

**Before:**
```bash
vault write auth/jwt/config \
    oidc_discovery_url="https://provider.com" \
    oidc_client_id="abc" \
    oidc_client_secret="secret"  # Required
```

**After:**
```bash
vault write auth/jwt/config \
    oidc_discovery_url="https://provider.com" \
    oidc_client_id="abc"  # Secret is optional
```

# Design of Change
How was this change implemented?
Modified configuration validation in `path_config.go` to make `oidc_client_secret` optional when `oidc_client_id` is provided. Key changes:

- Relaxed validation to allow `oidc_client_id` without `oidc_client_secret`
- Updated `authType()` to recognize OIDC flow with `client_id` only
- Modified provider creation to handle empty secrets and enable PKCE
- Added test coverage for public client configuration
- Updated documentation and field descriptions
The existing OIDC provider library automatically uses PKCE when no client secret is provided, securing the token exchange without requiring a shared secret.

# Related Issues/Pull Requests
- [X] [Issue #116](https://github.com/hashicorp/vault-plugin-auth-jwt/issues/116)

# Contributor Checklist
- [X] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
https://github.com/hashicorp/web-unified-docs/pull/1611
- [X] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
```
=== RUN   TestConfig_OIDC_Write
--- PASS: TestConfig_OIDC_Write (0.55s)
=== RUN   TestConfig_OIDC_Write_ProviderConfig
--- PASS: TestConfig_OIDC_Write_ProviderConfig (0.15s)
PASS
ok      github.com/hashicorp/vault-plugin-auth-jwt      1.322s
```
- [X] Backwards compatible
This change is fully backwards compatible. Existing configurations with client secrets continue to work unchanged. The change only relaxes validation to make client_secret optional.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
