### PR TITLE
Fix JSON pointer claim writes loosing root updates in overage scenarios

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -16,18 +16,24 @@ import (
 	"github.com/ryanuber/go-glob"
 )
 
+// Package-level vars to allow stubbing in tests.
+// (Default to pointerstructure implementations.)
+var (
+	pointerSet = pointerstructure.Set
+	pointerGet = pointerstructure.Get
+)
+
 // setClaim sets a claim value from allClaims given a provided claim string.
 // If this string is a valid JSONPointer, it will be interpreted as such to locate
 // the claim. Otherwise, the claim string will be used directly.
 func setClaim(logger log.Logger, allClaims map[string]interface{}, claim string, val interface{}) interface{} {
-	var err error
-
+	// Non-JSON pointer path: simple map write.
 	if !strings.HasPrefix(claim, "/") {
 		allClaims[claim] = val
 		return val
 	}
 
-	updated, err := pointerstructure.Set(allClaims, claim, val)
+	updated, err := pointerSet(allClaims, claim, val)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("unable to set %s in claims: %s", claim, err.Error()))
 		return nil
@@ -36,17 +42,25 @@ func setClaim(logger log.Logger, allClaims map[string]interface{}, claim string,
 	// If Set returns an updated root object, sync it back into allClaims.
 	// This preserves the original map reference held by callers.
 	if m, ok := updated.(map[string]interface{}); ok {
+		// Defensive copy to avoid aliasing if updated happens to share memory.
+		tmpCopy := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			tmpCopy[k] = v
+		}
+
+		// Clear original map contents.
 		for k := range allClaims {
 			delete(allClaims, k)
 		}
-		for k, v := range m {
+
+		// Repopulate original map with updated root contents.
+		for k, v := range tmpCopy {
 			allClaims[k] = v
 		}
 	}
 
 	return updated
 }
-
 
 // getClaim returns a claim value from allClaims given a provided claim string.
 // If this string is a valid JSONPointer, it will be interpreted as such to locate
@@ -58,7 +72,7 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 	if !strings.HasPrefix(claim, "/") {
 		val = allClaims[claim]
 	} else {
-		val, err = pointerstructure.Get(allClaims, claim)
+		val, err = pointerGet(allClaims, claim)
 		if err != nil {
 			logger.Warn(fmt.Sprintf("unable to locate %s in claims: %s", claim, err.Error()))
 			return nil

--- a/claims_test.go
+++ b/claims_test.go
@@ -5,6 +5,7 @@ package jwtauth
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -662,5 +663,86 @@ func Test_normalizeList(t *testing.T) {
 		if ok != tt.ok {
 			t.Errorf("normalizeList() got ok = %v, want %v", ok, tt.ok)
 		}
+	}
+}
+
+// Test_setClaim_JSONPointerSyncReturnedRoot reproduces the regression fixed in PR #366:
+// pointerstructure.Set may return an updated root object rather than mutating in place.
+// If the returned root is not synchronized back into allClaims, subsequent getClaim calls
+// can read stale values (e.g., groups disappear), breaking policy mapping in Azure/Entra
+// "group overage" scenarios.
+func TestSetClaim_SyncsUpdatedRootIntoAllClaims_WhenPointerSetReturnsNewRoot(t *testing.T) {
+	logger := hclog.NewNullLogger()
+
+	// Save and restore the real function.
+	origPointerSet := pointerSet
+	defer func() { pointerSet = origPointerSet }()
+
+	origPointerGet := pointerGet
+	defer func() { pointerGet = origPointerGet }()
+
+	// Stub: do NOT mutate the passed-in allClaims.
+	// Instead, return a NEW root map that contains the expected structure.
+	pointerSet = func(curr interface{}, claim string, val interface{}) (interface{}, error) {
+		// Clone the current root into a new map (simulate "returned new root").
+		root := map[string]interface{}{}
+		if m, ok := curr.(map[string]interface{}); ok {
+			for k, v := range m {
+				root[k] = v
+			}
+		}
+
+		switch claim {
+		case "/a/b/c/d/groups":
+			root["a"] = map[string]interface{}{
+				"b": map[string]interface{}{
+					"c": map[string]interface{}{
+						"d": map[string]interface{}{
+							"groups": val,
+						},
+					},
+				},
+			}
+		case "/_claim_names/groups":
+			claimNames, _ := root["_claim_names"].(map[string]interface{})
+			if claimNames == nil {
+				claimNames = map[string]interface{}{}
+				root["_claim_names"] = claimNames
+			}
+			claimNames["groups"] = val
+		default:
+			return nil, fmt.Errorf("stub pointerSet received unexpected claim path: %s", claim)
+		}
+
+		return root, nil
+	}
+
+	allClaims := map[string]interface{}{}
+
+	groupsPath := "/a/b/c/d/groups"
+	groups := []interface{}{"g1", "g2", "g3"}
+
+	setClaim(logger, allClaims, groupsPath, groups)
+
+	// If setClaim does NOT sync the returned root into allClaims, this will be nil.
+	got := getClaim(logger, allClaims, groupsPath)
+	if got == nil {
+		t.Fatalf("expected %s to be readable; setClaim did not sync updated root into allClaims", groupsPath)
+	}
+
+	norm, ok := normalizeList(got)
+	if !ok || len(norm) != len(groups) {
+		t.Fatalf("expected normalizeList ok and %d groups, got ok=%v len=%d", len(groups), ok, len(norm))
+	}
+
+	// Additional pointer write to simulate distributed claim metadata.
+	setClaim(logger, allClaims, "/_claim_names/groups", "src1")
+	if v := getClaim(logger, allClaims, "/_claim_names/groups"); v != "src1" {
+		t.Fatalf("expected /_claim_names/groups==src1, got %#v", v)
+	}
+
+	got2 := getClaim(logger, allClaims, groupsPath)
+	if got2 == nil {
+		t.Fatalf("expected %s to remain readable after metadata write; got nil", groupsPath)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes a case where identity policy mapping may fail for Azure / Entra ID users in group overage scenarios (200+ groups), even though Vault successfully retrieves the full group list via `fetchGroups`.

In certain cases, group data was written into the claims structure but later reads did not see those updates, resulting in only the default policy being attached.

### High-Level flow
1. user hits POST `/v1/auth/jwt/login` API [here](https://developer.hashicorp.com/vault/api-docs/auth/jwt#jwt-login)
2. Vault receives the [JWT](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference) issued by Azure (Entra ID) 
3. Vault:
* validates signature
* parses claim
* ** Builds allClaims (map[string]interface{})**
* Applies role configuration 
* Maps groups → entity aliases → policies

The issue occurs during construction and mutation of `allClaims`.

---
### Normal JWT vs. Overage JWT 
Azure docs [here](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference) (search "overage" or "groups")

**Normal case: small number of groups**
```
{
  "sub": "user123",
  "groups": ["groupA"]
}
```
Vault reads groups directly and maps them to policies.

**Overage case (ex: 200+ groups)**
Azure does not include all groups directly in the token. Instead, it emits distributed claim metadata, for example:
```
{
  "sub": "user123",
  "_claim_names": {
    "groups": "src1"
  },
  "_claim_sources": {
    "src1": {
      "endpoint": "https://graph.microsoft.com/v1.0/me/memberObjects"
    }
  }
}
```

Vault:
* Detects overage
* Calls Microsoft Graph
* Fetches the full group list
* Injects those groups back into allClaims

That injection step uses JSON Pointer paths via `pointerstructure.Set`.

## The problem
When claims are written using JSON pointer paths, we call:
```
pointerstructure.Set(allClaims, claim, val)
```
`pointestructure.Set` returns the complete updated document and may return a new root map instead of mutating the existing map in place.

Previously:
* We returned the result of `Set(...)`
* But did not ensure allClaims reflected that returned root

If `Set(...)` returned a new root, Vault would continue reading from the original `allClaims` reference. 
As a result:
* Logs showed groups successfully fetched
* Later getClaim(...) calls did not see those groups
* Only the default policy was attached

### The fix
setClaim now:
* Calls `pointerSet(...)`
* If the returned value is a `map[string]interface{}` (root document), copies it back into the original `allClaims` reference

This guarantees that:
* If `pointerstructure.Set` returns a new root,
* `allClaims` reflects the updated structure,
* Subsequent `getClaim(...)` calls see the injected groups,
* Policies are mapped correctly.

This change only affects JSON pointer-based claim writes (paths starting with /).
Non-pointer claim handling remains unchanged.

# Related Issues/Pull Requests
// TODO there is a related PR that first handled overage.
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
