### PR TITLE
Add Kubernetes JWT provider

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -173,6 +173,13 @@ func (b *jwtAuthBackend) jwtValidator(config *jwtConfig) (*jwt.Validator, error)
 	case OIDCDiscovery:
 		keySet, err = jwt.NewOIDCDiscoveryKeySet(b.providerCtx, config.OIDCDiscoveryURL, config.OIDCDiscoveryCAPEM)
 		keySets = []jwt.KeySet{keySet}
+	case CustomProviderDiscovery:
+		pConfig, initErr := NewProviderConfig(b.providerCtx, config, ProviderMap())
+		if initErr != nil {
+			return nil, initErr
+		}
+		keySet, err = pConfig.(KeySetDiscovery).NewKeySet(b.providerCtx)
+		keySets = []jwt.KeySet{keySet}
 	default:
 		return nil, errors.New("unsupported config type")
 	}

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1417,6 +1418,8 @@ type oidcProvider struct {
 	code          string
 	codeChallenge string
 	customClaims  map[string]interface{}
+	requests      []*http.Request
+	requestsMutex sync.Mutex
 }
 
 func newOIDCProvider(t *testing.T) *oidcProvider {
@@ -1429,6 +1432,10 @@ func newOIDCProvider(t *testing.T) *oidcProvider {
 
 func (o *oidcProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+
+	o.requestsMutex.Lock()
+	o.requests = append(o.requests, r)
+	o.requestsMutex.Unlock()
 
 	switch r.URL.Path {
 	case "/.well-known/openid-configuration":
@@ -1507,6 +1514,27 @@ func (o *oidcProvider) getTLSCert() (string, error) {
 	}
 
 	return pemBuf.String(), nil
+}
+
+// getRequests returns and clears the list of requests received by the mock provider.
+func (o *oidcProvider) getRequests() []*http.Request {
+	o.requestsMutex.Lock()
+	defer o.requestsMutex.Unlock()
+	r := o.requests
+	o.requests = []*http.Request{}
+	return r
+}
+
+func (o *oidcProvider) issuerToken(subject string) string {
+	stdClaims := jwt.Claims{
+		Subject:   subject,
+		Issuer:    o.server.URL,
+		NotBefore: jwt.NewNumericDate(time.Now().Add(-5 * time.Second)),
+		Expiry:    jwt.NewNumericDate(time.Now().Add(5 * time.Second)),
+		Audience:  jwt.Audience{o.clientID},
+	}
+	jwtData, _ := getTestJWT(o.t, ecdsaPrivKey, stdClaims, o.customClaims)
+	return jwtData
 }
 
 func getQueryParam(t *testing.T, inputURL, param string) string {

--- a/provider_config.go
+++ b/provider_config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/cap/jwt"
 	"golang.org/x/oauth2"
 )
 
@@ -21,6 +22,7 @@ func ProviderMap() map[string]CustomProvider {
 		"gsuite":     &GSuiteProvider{},
 		"secureauth": &SecureAuthProvider{},
 		"ibmisam":    &IBMISAMProvider{},
+		"kubernetes": &KubernetesProvider{},
 	}
 }
 
@@ -66,4 +68,10 @@ type UserInfoFetcher interface {
 type GroupsFetcher interface {
 	// FetchGroups queries for groups claims during login
 	FetchGroups(context.Context, *jwtAuthBackend, map[string]interface{}, *jwtRole, oauth2.TokenSource) (interface{}, error)
+}
+
+// KeySetDiscovery - Optional support for custom provider-specific discovery mechanism
+type KeySetDiscovery interface {
+	// NewKeySet returns a new KeySet that will be used to verify JWTs
+	NewKeySet(context.Context) (jwt.KeySet, error)
 }

--- a/provider_kubernetes.go
+++ b/provider_kubernetes.go
@@ -1,0 +1,182 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package jwtauth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/cap/jwt"
+	"github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/oauth2"
+)
+
+// Global variables instead of const to allow test cases to overwrite paths.
+var (
+	// localJWTPath is the path to the Kubernetes Service Account JWT token file.
+	localJWTPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	// localCACertPath is the path to the Kubernetes API server CA certificate.
+	localCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
+type KubernetesProvider struct {
+	// oidcDiscoveryURL is the OIDC discovery URL for the Kubernetes API server.
+	oidcDiscoveryURL string
+}
+
+func (k *KubernetesProvider) Initialize(_ context.Context, jc *jwtConfig) error {
+	// Verify that no conflicting configuration is set.
+	if jc.OIDCDiscoveryURL != "" {
+		return errors.New("oidc_discovery_url must not be set when using the kubernetes provider")
+	}
+
+	if jc.OIDCDiscoveryCAPEM != "" {
+		return errors.New("oidc_discovery_ca_pem must not be set when using the kubernetes provider")
+	}
+
+	if jc.JWKSURL != "" {
+		return errors.New("jwks_url must not be set when using the kubernetes provider")
+	}
+
+	if jc.JWKSCAPEM != "" {
+		return errors.New("jwks_ca_pem must not be set when using the kubernetes provider")
+	}
+
+	// Verify that the Service Account token and CA certificate files are accessible.
+	_, err := os.ReadFile(localJWTPath)
+	if err != nil {
+		return fmt.Errorf("error reading service account token file: %w", err)
+	}
+
+	_, err = os.ReadFile(localCACertPath)
+	if err != nil {
+		return fmt.Errorf("error reading CA certificate file: %w", err)
+	}
+
+	// Verify that the environment variables are set for the Kubernetes API server address.
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" || os.Getenv("KUBERNETES_SERVICE_PORT") == "" {
+		return errors.New("KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT environment variables must be set when using the kubernetes provider")
+	}
+
+	// For security, the OIDC discovery URL is derived from Kubernetes-provided environment variables in the pod,
+	// rather than accepting a user-supplied URL.
+	k.oidcDiscoveryURL = "https://" + net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
+
+	return nil
+}
+
+func (k *KubernetesProvider) SensitiveKeys() []string {
+	return []string{}
+}
+
+func (k *KubernetesProvider) NewKeySet(ctx context.Context) (jwt.KeySet, error) {
+	certPool := x509.NewCertPool()
+	caCert, err := os.ReadFile(localCACertPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading CA certificate file: %w", err)
+	}
+
+	certPool.AppendCertsFromPEM([]byte(caCert))
+
+	tlsConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	baseTransport := cleanhttp.DefaultPooledTransport()
+	baseTransport.TLSClientConfig = tlsConfig
+
+	saAuthTransport := &bearerAuthRoundTripper{
+		baseTransport:      baseTransport,
+		kubernetesProvider: k,
+	}
+
+	httpClient := &http.Client{
+		Transport: saAuthTransport,
+	}
+
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+
+	jwksURL, err := retrieveJWKSURL(ctx, k.oidcDiscoveryURL+"/.well-known/openid-configuration", httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return jwt.NewJSONWebKeySet(ctx, jwksURL, "")
+}
+
+// retrieveJWKSURL fetches the OIDC discovery document from the specified well-known URL and extracts the JWKS URI.
+//
+// This function is similar to jwt.NewOIDCDiscoveryKeySet(), but it skips validating the "issuer" field:
+// this provider relies on Service IP address from KUBERNETES_SERVICE_HOST environment variable on connecting
+// the API server, which does not match the issuer field in the discovery document.
+func retrieveJWKSURL(ctx context.Context, wellKnown string, client *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s: %s", resp.Status, body)
+	}
+
+	var p struct {
+		JWKSURL string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(body, &p); err != nil {
+		return "", err
+	}
+
+	if p.JWKSURL == "" {
+		return "", errors.New("jwks_uri not found in OIDC discovery document")
+	}
+
+	return p.JWKSURL, nil
+}
+
+// bearerAuthRoundTripper is an http.RoundTripper that adds an Authorization header
+// containing the Kubernetes Service Account token as a bearer token.
+type bearerAuthRoundTripper struct {
+	baseTransport      http.RoundTripper
+	kubernetesProvider *KubernetesProvider
+}
+
+func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return rt.baseTransport.RoundTrip(req)
+	}
+
+	// Clone the request to avoid modifying the original.
+	req = req.Clone(req.Context())
+
+	// Read the token from disk on each request.
+	// Since discovery and JWKS downloads are infrequent, caching in memory has minimal benefit.
+	token, err := os.ReadFile(localJWTPath)
+	if err == nil {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", strings.TrimSpace(string(token))))
+	}
+	// If token read fails, proceed without Authorization header.
+
+	return rt.baseTransport.RoundTrip(req)
+}

--- a/provider_kubernetes_test.go
+++ b/provider_kubernetes_test.go
@@ -1,0 +1,271 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package jwtauth
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesProviderWithOIDCDiscovery(t *testing.T) {
+	b, storage := getBackend(t)
+	server, token := mockKubernetesAPIServer(t)
+
+	// Configure the backend with OIDC discovery URL and Kubernetes provider.
+	// The provider uses the service account token for authentication and the pod CA cert for server validation.
+	data := map[string]interface{}{
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	// Verify that the request to the API server includes Authorization header with the bearer token.
+	requests := server.getRequests()
+	require.Len(t, requests, 1)
+	// First request for OIDC discovery at validation of configuration.
+	require.Equal(t, "/.well-known/openid-configuration", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+
+	createRole(t, b, storage)
+
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:vault-client"))
+
+	requests = server.getRequests()
+	require.Len(t, requests, 2)
+	// Second request for OIDC discovery when first login occurs.
+	require.Equal(t, "/.well-known/openid-configuration", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+	// Third request for JWKS URI, also at first login.
+	require.Equal(t, "/certs", requests[1].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[1].Header.Get("Authorization"))
+
+	// Re-attempt login to verify that JWKS caching works and no new request is made to JWKS endpoint.
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:vault-client"))
+	requests = server.getRequests()
+	require.Len(t, requests, 0)
+}
+
+func TestKubernetesProviderWithJWKSURL(t *testing.T) {
+	b, storage := getBackend(t)
+	server, token := mockKubernetesAPIServer(t)
+
+	// Configure the backend with JWKS URL and Kubernetes provider.
+	// The provider uses the service account token for authentication and the pod CA cert for server validation.
+	data := map[string]interface{}{
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+
+	createRole(t, b, storage)
+
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:vault-client"))
+
+	// Verify that the request to the API server includes Authorization header with the bearer token.
+	requests := server.getRequests()
+	require.Len(t, requests, 3)
+	// First request for OIDC discovery at validation of configuration.
+	require.Equal(t, "/.well-known/openid-configuration", requests[0].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[0].Header.Get("Authorization"))
+	// Second request for OIDC discovery when first login occurs.
+	require.Equal(t, "/.well-known/openid-configuration", requests[1].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[1].Header.Get("Authorization"))
+	// Third request for JWKS URI, also at first login.
+	require.Equal(t, "/certs", requests[2].URL.Path)
+	require.Equal(t, "Bearer "+token, requests[2].Header.Get("Authorization"))
+
+	// Re-attempt login to verify that JWKS caching works and no new request are made.
+	login(t, b, storage, server.issuerToken("system:serviceaccount:default:vault-client"))
+	requests = server.getRequests()
+	require.Len(t, requests, 0)
+}
+
+func TestKubernetesProviderWithInvalidConfig(t *testing.T) {
+	b, storage := getBackend(t)
+
+	tempDir := t.TempDir()
+	caCertPath := path.Join(tempDir, "ca.crt")
+	err := os.WriteFile(caCertPath, []byte("test-ca-cert-data"), 0o600)
+	require.NoError(t, err)
+
+	// Configure jwks_ca_pem with Kubernetes provider.
+	data := map[string]interface{}{
+		"jwks_url":    "https://example.com/",
+		"jwks_ca_pem": caCertPath,
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+
+	// Configure oidc_discovery_ca_pem with Kubernetes provider.
+	data = map[string]interface{}{
+		"oidc_discovery_url":    "https://example.com/",
+		"oidc_discovery_ca_pem": caCertPath,
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err = b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func TestKubernetesProviderWithInvalidTokenFile(t *testing.T) {
+	b, storage := getBackend(t)
+	server, _ := mockKubernetesAPIServer(t)
+
+	// Overwrite the global SA token path variable to point to a non-existing file.
+	localJWTPath = "/non/existing/token/file"
+
+	data := map[string]interface{}{
+		"jwks_url": server.server.URL + "/certs",
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func TestKubernetesProviderWithInvalidCACertFile(t *testing.T) {
+	b, storage := getBackend(t)
+	server, _ := mockKubernetesAPIServer(t)
+
+	// Overwrite the global CA cert path variable to point to a non-existing file.
+	localCACertPath = "/non/existing/ca/cert/file"
+
+	data := map[string]interface{}{
+		"jwks_url": server.server.URL + "/certs",
+		"provider_config": map[string]interface{}{
+			"provider": "kubernetes",
+		},
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+}
+
+func mockKubernetesAPIServer(t *testing.T) (*oidcProvider, string) {
+	t.Helper()
+
+	// Start the test OIDC provider.
+	server := newOIDCProvider(t)
+	server.clientID = "https://kubernetes.default.svc.cluster.local"
+	t.Cleanup(server.server.Close)
+	cert, err := server.getTLSCert()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+
+	// Write server cert to a file.
+	certFile := path.Join(tempDir, "ca.crt")
+	err = os.WriteFile(certFile, []byte(cert), 0o600)
+	require.NoError(t, err)
+
+	// Write token that will be used to authenticate towards Kubernetes API server.
+	tokenFile := path.Join(tempDir, "token")
+	token := "my-kubernetes-service-account-token"
+	err = os.WriteFile(tokenFile, []byte(token), 0o600)
+	require.NoError(t, err)
+
+	// Overwrite the global cert and token variables so that Kubernetes provider uses them instead of the pod paths.
+	// This is safe as long as tests are not run in parallel.
+	localCACertPath = certFile
+	localJWTPath = tokenFile
+
+	parsedURL, _ := url.Parse(server.server.URL)
+	t.Setenv("KUBERNETES_SERVICE_HOST", parsedURL.Hostname())
+	t.Setenv("KUBERNETES_SERVICE_PORT", parsedURL.Port())
+
+	return server, token
+}
+
+func createRole(t *testing.T, b logical.Backend, s logical.Storage) {
+	t.Helper()
+
+	data := map[string]interface{}{
+		"role_type":       "jwt",
+		"user_claim":      "sub",
+		"bound_subject":   "system:serviceaccount:default:vault-client",
+		"bound_audiences": "https://kubernetes.default.svc.cluster.local",
+	}
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/my-role",
+		Storage:   s,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+}
+
+func login(t *testing.T, b logical.Backend, s logical.Storage, jwt string) {
+	t.Helper()
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"role": "my-role",
+			"jwt":  jwt,
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError())
+}


### PR DESCRIPTION
# Overview
This change implements a Kubernetes-specific JWT provider that uses the pod's Service Account token and CA certificate for authenticating requests to the Kubernetes API server's OIDC endpoints.

This approach avoids requiring RBAC policy changes that would otherwise be needed to allow anonymous access to the OIDC discovery and JWKS endpoints.

The provider is configured in following way

```shell
$ vault write auth/jwt/config - <<EOF
{
    "oidc_discovery_url": "https://kubernetes.default.svc.cluster.local",
    "provider_config": {
        "provider": "kubernetes"
    }
}
EOF
```

The provider uses the default mount paths `/var/run/secrets/kubernetes.io/serviceaccount/token` and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` which removes burden from user to configure anything further than setting the discovery URL and selecting the Kubernetes provider. The default automounted token is sufficient, no RBAC permissions need to be created.

# Design of Change

This PR adds a new provider, `kubernetes`, which implements the new `KeySetDiscovery` interface. This interface allows the provider to handle fetching the discovery document, keys and return `jwt.KeySet`, enabling the Kubernetes provider to use a custom `http.RoundTripper` for authenticated all HTTP requests towards Kubernetes API server.

The provider "re-implements" discovery document download itself (`retrieveJWKSURL`, similar to `jwt.NewOIDCDiscoveryKeySet()`). This duplication could be eliminated if https://github.com/hashicorp/cap/issues/176 is resolved.


# Related Issues/Pull Requests
Fixes #367

I have previously submitted this patch also to the OpenBao project https://github.com/openbao/openbao/pull/2114

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
