### PR TITLE
Allow non-string claim values in claim_mappings

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -67,7 +67,9 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 }
 
 // extractMetadata builds a metadata map from a set of claims and claims mappings.
-// The referenced claims must be strings and the claims mappings must be of the structure:
+// Claim values can be strings, numbers, booleans, or arrays/objects — non-string
+// values are converted to their JSON string representation. The claims mappings
+// must be of the structure:
 //
 //	{
 //	    "/some/claim/pointer": "metadata_key1",
@@ -78,15 +80,43 @@ func extractMetadata(logger log.Logger, allClaims map[string]interface{}, claimM
 	metadata := make(map[string]string)
 	for source, target := range claimMappings {
 		if value := getClaim(logger, allClaims, source); value != nil {
-			strValue, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("error converting claim '%s' to string", source)
+			strValue, err := claimToString(value)
+			if err != nil {
+				return nil, fmt.Errorf("error converting claim '%s' to string: %w", source, err)
 			}
 
 			metadata[target] = strValue
 		}
 	}
 	return metadata, nil
+}
+
+// claimToString converts a claim value to its string representation.
+// Strings are returned as-is; numbers and booleans use their standard
+// representations; slices and maps are JSON-encoded.
+func claimToString(v interface{}) (string, error) {
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	case json.Number:
+		return val.String(), nil
+	case bool:
+		return strconv.FormatBool(val), nil
+	case []interface{}:
+		jsonBytes, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("unable to marshal to JSON: %w", err)
+		}
+		return string(jsonBytes), nil
+	case map[string]interface{}:
+		jsonBytes, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("unable to marshal to JSON: %w", err)
+		}
+		return string(jsonBytes), nil
+	default:
+		return fmt.Sprintf("%v", val), nil
+	}
 }
 
 // validateAudience checks whether any of the audiences in audClaim match those

--- a/claims_test.go
+++ b/claims_test.go
@@ -176,15 +176,103 @@ func TestExtractMetadata(t *testing.T) {
 			false,
 		},
 		{
-			"error: non-string data",
+			"numeric claim (json.Number via getClaim)",
 			map[string]interface{}{
-				"data1": 42,
+				"data1": "foo",
+				"exp":   float64(1587564736),
 			},
 			map[string]string{
 				"data1": "val1",
+				"exp":   "expiry",
 			},
-			nil,
-			true,
+			map[string]string{
+				"val1":   "foo",
+				"expiry": "1587564736",
+			},
+			false,
+		},
+		{
+			"boolean claim",
+			map[string]interface{}{
+				"email_verified": true,
+				"is_admin":       false,
+			},
+			map[string]string{
+				"email_verified": "verified",
+				"is_admin":       "admin",
+			},
+			map[string]string{
+				"verified": "true",
+				"admin":    "false",
+			},
+			false,
+		},
+		{
+			"array claim (string list)",
+			map[string]interface{}{
+				"groups": []interface{}{"group1", "group2", "group3"},
+			},
+			map[string]string{
+				"groups": "user_groups",
+			},
+			map[string]string{
+				"user_groups": `["group1","group2","group3"]`,
+			},
+			false,
+		},
+		{
+			"nested object claim",
+			map[string]interface{}{
+				"address": map[string]interface{}{
+					"street": "123 Main St",
+					"city":   "Springfield",
+				},
+			},
+			map[string]string{
+				"address": "addr",
+			},
+			map[string]string{
+				"addr": `{"city":"Springfield","street":"123 Main St"}`,
+			},
+			false,
+		},
+		{
+			"mixed types",
+			map[string]interface{}{
+				"name":   "alice",
+				"age":    float64(30),
+				"active": true,
+				"roles":  []interface{}{"reader", "writer"},
+			},
+			map[string]string{
+				"name":   "meta_name",
+				"age":    "meta_age",
+				"active": "meta_active",
+				"roles":  "meta_roles",
+			},
+			map[string]string{
+				"meta_name":   "alice",
+				"meta_age":    "30",
+				"meta_active": "true",
+				"meta_roles":  `["reader","writer"]`,
+			},
+			false,
+		},
+		{
+			"json.Number claim",
+			map[string]interface{}{
+				"acct": json.Number("0"),
+				"nbf":  json.Number("1587560836"),
+			},
+			map[string]string{
+				"acct": "account",
+				"nbf":  "not_before",
+			},
+			map[string]string{
+				"account":    "0",
+				"not_before": "1587560836",
+			},
+			false,
 		},
 	}
 
@@ -195,6 +283,36 @@ func TestExtractMetadata(t *testing.T) {
 		}
 		if diff := deep.Equal(actual, test.expected); diff != nil {
 			t.Fatalf("case '%s': expected results: %v", test.testCase, diff)
+		}
+	}
+}
+
+func TestClaimToString(t *testing.T) {
+	tests := []struct {
+		testCase string
+		input    interface{}
+		expected string
+	}{
+		{"string", "hello", "hello"},
+		{"empty string", "", ""},
+		{"json.Number integer", json.Number("42"), "42"},
+		{"json.Number float", json.Number("3.14"), "3.14"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"string slice", []interface{}{"a", "b", "c"}, `["a","b","c"]`},
+		{"mixed slice", []interface{}{"a", json.Number("1"), true}, `["a",1,true]`},
+		{"map", map[string]interface{}{"k": "v"}, `{"k":"v"}`},
+		{"int (default branch)", 99, "99"},
+		{"float64 (default branch)", float64(2.5), "2.5"},
+	}
+
+	for _, test := range tests {
+		result, err := claimToString(test.input)
+		if err != nil {
+			t.Fatalf("case '%s': unexpected error: %v", test.testCase, err)
+		}
+		if result != test.expected {
+			t.Fatalf("case '%s': expected %q, got %q", test.testCase, test.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
# Overview

Operators using `claim_mappings` with JWT/OIDC auth could not map non-string claims (numbers, booleans, arrays, objects) to entity alias metadata. Any such mapping failed with `"error converting claim '...' to string"`. This affected anyone integrating with providers like Azure AD or Okta that return common non-string claims such as `exp`, `email_verified`, or `groups`.

This change makes `extractMetadata` convert non-string claim values to their string representation instead of rejecting them. String claims behave identically to before. Numbers and booleans use their standard Go string forms; arrays and objects are JSON-encoded. No configuration changes are required.

# Design of Change

* A new `claimToString` helper in `claims.go` uses a type switch to handle each type produced by Go's JSON unmarshalling (`string`, `json.Number`, `bool`, `[]interface{}`, `map[string]interface{}`), with a `fmt.Sprintf` fallback for unexpected types. 
* `extractMetadata` delegates to this helper instead of the previous hard `value.(string)` type assertion.

# Related Issues/Pull Requests

Fixes [#109](https://github.com/hashicorp/vault-plugin-auth-jwt/issues/109)

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  → No docs change needed. `claim_mappings` already documents mapping claims to  metadata keys. This relaxes the type constraint without altering the configuration schema or API surface.
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  → Single commit revert; no migration or state changes involved.
- [x] If applicable, I've documented the impact of any changes to security controls.
  → No changes to security controls. Claim values are converted to opaque strings stored in entity metadata.