### PR TITLE
jwt: return 400 when user_claim value is empty string

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -249,6 +249,9 @@ func (b *jwtAuthBackend) createIdentity(ctx context.Context, allClaims map[strin
 	if !ok {
 		return nil, nil, fmt.Errorf("claim %q could not be converted to string", role.UserClaim)
 	}
+	if userName == "" {
+		return nil, nil, fmt.Errorf("claim %q must not be empty", role.UserClaim)
+	}
 
 	pConfig, err := NewProviderConfig(ctx, b.cachedConfig, ProviderMap())
 	if err != nil {


### PR DESCRIPTION
When the configured user_claim resolves to an empty string in the JWT, createIdentity passes an empty alias name to Vault core, which has a hard constraint that alias names must be non-empty and returns HTTP 500 ("missing name in alias").

Add an explicit check after the string type assertion so the plugin returns a descriptive HTTP 400 instead, consistent with how nil and non-string values are already handled.

The group alias loop in the same function already skips empty strings (line 295); this brings user alias handling in line with that behavior.

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
