### PR TITLE
Add support for claims parameter

### DIFF
--- a/path_oidc.go
+++ b/path_oidc.go
@@ -478,6 +478,9 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 		oidc.WithAudiences(role.BoundAudiences...),
 		oidc.WithScopes(role.OIDCScopes...),
 	}
+	if role.OIDCClaims != "" {
+		options = append(options, oidc.WithClaims([]byte(role.OIDCClaims)))
+	}
 
 	if config.hasType(responseTypeIDToken) {
 		options = append(options, oidc.WithImplicitFlow())

--- a/path_oidc_test.go
+++ b/path_oidc_test.go
@@ -65,6 +65,7 @@ func TestOIDC_AuthURL(t *testing.T) {
 		"user_claim":            "email",
 		"bound_audiences":       "vault",
 		"allowed_redirect_uris": []string{"https://example.com"},
+		"oidc_claims":           `{"id_token":{"email":{"essential":true}}}`,
 	}
 
 	req = &logical.Request{

--- a/path_role.go
+++ b/path_role.go
@@ -5,6 +5,7 @@ package jwtauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -150,6 +151,10 @@ for referencing claims.`,
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of OIDC scopes`,
 			},
+			"oidc_claims": {
+				Type:        framework.TypeString,
+				Description: `JSON string of OIDC claims to request`,
+			},
 			"allowed_redirect_uris": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of allowed values for redirect_uri`,
@@ -221,6 +226,7 @@ type jwtRole struct {
 	UserClaim            string                 `json:"user_claim"`
 	GroupsClaim          string                 `json:"groups_claim"`
 	OIDCScopes           []string               `json:"oidc_scopes"`
+	OIDCClaims           string                 `json:"oidc_claims"`
 	AllowedRedirectURIs  []string               `json:"allowed_redirect_uris"`
 	VerboseOIDCLogging   bool                   `json:"verbose_oidc_logging"`
 	MaxAge               time.Duration          `json:"max_age"`
@@ -331,6 +337,7 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 		"groups_claim":            role.GroupsClaim,
 		"allowed_redirect_uris":   role.AllowedRedirectURIs,
 		"oidc_scopes":             role.OIDCScopes,
+		"oidc_claims":             role.OIDCClaims,
 		"verbose_oidc_logging":    role.VerboseOIDCLogging,
 		"max_age":                 int64(role.MaxAge.Seconds()),
 	}
@@ -535,6 +542,20 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 
 	if oidcScopes, ok := data.GetOk("oidc_scopes"); ok {
 		role.OIDCScopes = oidcScopes.([]string)
+	}
+
+	if oidcClaims, ok := data.GetOk("oidc_claims"); ok {
+		claimsStr := oidcClaims.(string)
+		// Allow unsetting the OIDC claims by passing an empty string
+		if claimsStr == "" {
+			role.OIDCClaims = ""
+		} else {
+			// Check that the oidc_claims is a valid JSON string (since it will be sent as-is)
+			if !json.Valid([]byte(claimsStr)) {
+				return logical.ErrorResponse("'oidc_claims' must be a valid JSON string"), nil
+			}
+			role.OIDCClaims = claimsStr
+		}
 	}
 
 	if allowedRedirectURIs, ok := data.GetOk("allowed_redirect_uris"); ok {

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -516,6 +516,36 @@ func TestPath_Create(t *testing.T) {
 			t.Fatalf("unexpected err: %v", resp)
 		}
 	})
+	// invalid JSON in oidc_claims should be rejected
+	t.Run("invalid oidc_claims json", func(t *testing.T) {
+		b, storage := getBackend(t)
+		data := map[string]interface{}{
+			"role_type":             "oidc",
+			"user_claim":            "user",
+			"policies":              "test",
+			"bound_audiences":       "vault",
+			"allowed_redirect_uris": []string{"https://example.com"},
+			"oidc_claims":           "{not json", // malformed
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "role/invalid-claims",
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || !resp.IsError() {
+			t.Fatalf("expected error response, got %#v", resp)
+		}
+		if resp.Error().Error() != "'oidc_claims' must be a valid JSON string" {
+			t.Fatalf("unexpected error message: %s", resp.Error().Error())
+		}
+	})
 }
 
 func TestPath_OIDCCreate(t *testing.T) {
@@ -529,6 +559,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 				"bar": "baz",
 			},
 			"oidc_scopes":           []string{"email", "profile"},
+			"oidc_claims":           `{"foo":"bar"}`,
 			"allowed_redirect_uris": []string{"https://example.com", "http://localhost:8250"},
 			"claim_mappings": map[string]string{
 				"foo": "a",
@@ -569,6 +600,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 				"bar": "b",
 			},
 			OIDCScopes:       []string{"email", "profile"},
+			OIDCClaims:       `{"foo":"bar"}`,
 			UserClaim:        "user",
 			GroupsClaim:      "groups",
 			TTL:              1 * time.Second,
@@ -613,6 +645,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 				"bar": "baz",
 			},
 			"oidc_scopes":           []string{"email", "profile"},
+			"oidc_claims":           `{"foo":"bar"}`,
 			"allowed_redirect_uris": []string{"https://example.com", "http://localhost:8250"},
 			"claim_mappings": map[string]string{
 				"foo":        "a",
@@ -659,6 +692,7 @@ func TestPath_OIDCCreate(t *testing.T) {
 				"bar": "baz",
 			},
 			"oidc_scopes":           []string{"email", "profile"},
+			"oidc_claims":           `{"foo":"bar"}`,
 			"allowed_redirect_uris": []string{"https://example.com", "http://localhost:8250"},
 			"claim_mappings": map[string]string{
 				"foo": "a",
@@ -749,6 +783,7 @@ func TestPath_Read(t *testing.T) {
 		"bound_audiences":       "vault",
 		"allowed_redirect_uris": []string{"http://127.0.0.1"},
 		"oidc_scopes":           []string{"email", "profile"},
+		"oidc_claims":           `{"foo":"bar"}`,
 		"user_claim":            "user",
 		"groups_claim":          "groups",
 		"bound_cidrs":           "127.0.0.1/8",
@@ -771,6 +806,7 @@ func TestPath_Read(t *testing.T) {
 		"bound_audiences":         []string{"vault"},
 		"allowed_redirect_uris":   []string{"http://127.0.0.1"},
 		"oidc_scopes":             []string{"email", "profile"},
+		"oidc_claims":             `{"foo":"bar"}`,
 		"user_claim":              "user",
 		"user_claim_json_pointer": false,
 		"groups_claim":            "groups",


### PR DESCRIPTION
# Overview

Adds support for an `oidc_claims` attribute on OIDC roles.

- **Who**: Vault users running the oidc auth plugin who need to request specific claims from their identity provider.

- **What**: Introduces a new role field that takes a JSON string. When present, the backend includes it as the `claims` parameter on the generated OIDC authorization URL.

- **Why**: The [OpenID Connect Core spec "claims" parameter](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) defines a `claims` request parameter that allows clients to explicitly request specific claims in the ID token or userinfo endpoint response. Previously there was no way to pass this parameter.

- **User impact**: Vault users can configure additional OIDC claims request for roles; the value is validated on write and returned by read operations. Not setting or unsetting this atribute will  cause the roles will behave exactly as before.

Example:

```bash
vault write auth/jwt/role/my-role \
  role_type="oidc" \
  user_claim="sub" \
  allowed_redirect_uris="https://example.com/callback" \
  oidc_claims='{"id_token":{"email":{"essential":true}}}'
```

# Design of Change

* Extend the role schema and storage to carry an `oidc_claims` string.
* Validate the string is valid JSON on writes.
* Surface it in role reads.
* Pass the content to `oidc.WithClaims` when building the auth URL.
* Unit tests cover role creation/read operations, invalid JSON rejection, and auth URL round-trips.

# Related Issues/Pull Requests
No related issues or pull requests

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
-> Don't know exactly how to update the documentation but i would add this:
> oidc_claims (string: "") – Specifies additional claims to request from the OIDC provider during authentication. This value should be a valid JSON string, formatted according to the [OpenID Connect Core spec "claims" parameter](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter).

[] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
