### PR TITLE
[CHANGELOG] Prepare for v0.26.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.26.1
+### March 20, 2026
+
+* Automated dependency upgrades (#374)
+* Update changelog for v0.26.0 release (#373)
+
 ## v0.26.0
 ### March 18, 2026
 


### PR DESCRIPTION
Changelog update for version [v0.26.1](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.26.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23329680327

