### PR TITLE
Fix float truncation in getClaim() bound_claims matching

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -52,16 +52,18 @@ func getClaim(logger log.Logger, allClaims map[string]interface{}, claim string)
 		}
 	}
 
-	// The claims unmarshalled by go-oidc don't use UseNumber, so there will
-	// be mismatches if they're coming in as float64 since Vault's config will
-	// be represented as json.Number. If the operator can coerce claims data to
-	// be in string form, there is no problem. As an alternative, we try to
-	// intelligently convert float32 and float64 to json.Number:
 	switch v := val.(type) {
-	case float32:
-		return json.Number(strconv.Itoa(int(v)))
 	case float64:
-		return json.Number(strconv.Itoa(int(v)))
+		if v == float64(int64(v)) {
+			return json.Number(strconv.FormatInt(int64(v), 10))
+		}
+		return json.Number(strconv.FormatFloat(v, 'f', -1, 64))
+	case float32:
+		f := float64(v)
+		if f == float64(int64(f)) {
+			return json.Number(strconv.FormatInt(int64(f), 10))
+		}
+		return json.Number(strconv.FormatFloat(f, 'f', -1, 64))
 	}
 	return val
 }

--- a/claims_test.go
+++ b/claims_test.go
@@ -58,6 +58,32 @@ func TestGetClaim(t *testing.T) {
 	}
 }
 
+func TestGetClaim_FloatPreservation(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  interface{}
+	}{
+		{"integer float64", float64(42), json.Number("42")},
+		{"fractional float64", float64(42.9), json.Number("42.9")},
+		{"negative float64", float64(-3.14), json.Number("-3.14")},
+		{"zero float64", float64(0), json.Number("0")},
+		{"large integer float64", float64(1234567890), json.Number("1234567890")},
+		{"integer float32", float32(42), json.Number("42")},
+		{"fractional float32", float32(42.5), json.Number("42.5")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := map[string]interface{}{"v": tt.value}
+			got := getClaim(hclog.NewNullLogger(), claims, "v")
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("getClaim() = %v, want %v, diff: %v", got, tt.want, diff)
+			}
+		})
+	}
+}
+
 func TestSetClaim(t *testing.T) {
 	data := `{
 		"a": 42,
@@ -319,13 +345,34 @@ func TestValidateBoundClaims(t *testing.T) {
 			name:            "invalid match with numeric claim conversion from float64",
 			boundClaimsType: "string",
 			boundClaims: map[string]interface{}{
-				// Numeric bound claims from Vault API are json.Number type
 				"foo": json.Number("456"),
 			},
 			allClaims: map[string]interface{}{
 				"foo": float64(123),
 			},
 			errExpected: true,
+		},
+		{
+			name:            "fractional float64 should not match truncated integer",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				"foo": json.Number("42"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float64(42.9),
+			},
+			errExpected: true,
+		},
+		{
+			name:            "fractional float64 exact match",
+			boundClaimsType: "string",
+			boundClaims: map[string]interface{}{
+				"foo": json.Number("42.9"),
+			},
+			allClaims: map[string]interface{}{
+				"foo": float64(42.9),
+			},
+			errExpected: false,
 		},
 		{
 			name:            "invalid match with numeric claim conversion from float32",


### PR DESCRIPTION
## Summary

`getClaim()` in `claims.go` converts `float64` claim values to integers via `strconv.Itoa(int(v))`, which silently truncates fractional parts. This causes incorrect `bound_claims` matching — e.g., a JWT with `accountId: 42.9` passes a role configured with `bound_claims: {"accountId": 42}`.

### Changes

- Replace `strconv.Itoa(int(v))` with `strconv.FormatFloat` / `strconv.FormatInt` to preserve fractional values while keeping whole numbers as integers for backward compatibility
- Add `TestGetClaim_FloatPreservation` covering integer, fractional, negative, and zero float values
- Add bound_claims test cases for fractional float64 rejection and exact match

### Verified against

- Vault 1.21.4 with vault-plugin-auth-jwt v0.25.0
- Bug also confirmed in v0.26.1

Fixes #376