### PR TITLE
Normalize Unicode in identity alias names to NFC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.31.0
 	golang.org/x/sync v0.17.0
+	golang.org/x/text v0.29.0
 	google.golang.org/api v0.251.0
 )
 
@@ -114,7 +115,6 @@ require (
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 // indirect
 	google.golang.org/grpc v1.75.1 // indirect

--- a/path_login.go
+++ b/path_login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/oauth2"
+	"golang.org/x/text/unicode/norm"
 )
 
 func pathLogin(b *jwtAuthBackend) *framework.Path {
@@ -249,6 +250,7 @@ func (b *jwtAuthBackend) createIdentity(ctx context.Context, allClaims map[strin
 	if !ok {
 		return nil, nil, fmt.Errorf("claim %q could not be converted to string", role.UserClaim)
 	}
+	userName = norm.NFC.String(userName)
 
 	pConfig, err := NewProviderConfig(ctx, b.cachedConfig, ProviderMap())
 	if err != nil {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/text/unicode/norm"
 )
 
 type H map[string]interface{}
@@ -1780,3 +1781,17 @@ AwEHoUQDQgAE+C3CyjVWdeYtIqgluFJlwZmoonphsQbj9Nfo5wrEutv+3RTFnDQh
 vttUajcFAcl4beR+jHFYC00vSO4i5jZ64g==
 -----END EC PRIVATE KEY-----`
 )
+
+func TestUnicodeNormalizationInCreateIdentity(t *testing.T) {
+	nfc := "caf\u00e9user"
+	nfd := "cafe\u0301user"
+
+	if nfc == nfd {
+		t.Fatal("test setup error: NFC and NFD forms should differ as raw strings")
+	}
+
+	normalized := norm.NFC.String(nfd)
+	if normalized != nfc {
+		t.Fatalf("NFC normalization failed: got %q, want %q", normalized, nfc)
+	}
+}


### PR DESCRIPTION
## Summary

Identity alias names derived from JWT `user_claim` are not Unicode-normalized before alias creation. Two JWTs with the same visual `sub` value in different Unicode representations (NFC vs NFD) create two distinct Vault entities, splitting a single logical user's identity.

### Changes

- Normalize `userName` to Unicode NFC form in `createIdentity()` before using it as the alias name
- Promote `golang.org/x/text` from indirect to direct dependency
- Add regression test verifying NFC/NFD equivalence

NFC is the standard normalization form recommended by RFC 8264 (PRECIS) for identity identifiers.

### Verified against

- Vault 1.21.4 with vault-plugin-auth-jwt v0.25.0
- Confirmed in v0.26.1

Fixes #377