### PR TITLE
ci: declare caller-side permissions for the 5 vault-workflows-common callers

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -3,6 +3,9 @@ on:
   push:
     paths:
     - '.github/workflows/**'
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/bulk-dep-upgrades.yaml
+++ b/.github/workflows/bulk-dep-upgrades.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Runs 12:00AM on the first of every month
     - cron: '0 0 1 * *'
+# Reusable bulk-dep workflow uses secrets.VAULT_ECO_GITHUB_TOKEN to open the
+# dependency PR; default GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   upgrade:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,6 +1,9 @@
 name: Go checks
 on:
   push:
+permissions:
+  contents: read
+
 jobs:
   go-checks:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -6,6 +6,12 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
+# Reusable Jira sync only reads issue/PR metadata; writes go to Jira.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   sync:
     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     # using `main` as the ref will keep your workflow up-to-date


### PR DESCRIPTION
All five workflows in this repo delegate to reusable workflows in `hashicorp/vault-workflows-common`. None of them currently set caller-side permissions, so the default `GITHUB_TOKEN` carries the org default. This PR pins each to the minimum scope the reusable actually needs:

| Workflow | Reusable | Scope |
|----------|----------|-------|
| `actionlint.yaml` | `actionlint.yaml@main` | `contents: read` |
| `bulk-dep-upgrades.yaml` | `bulk-dependency-updates.yaml@main` | `contents: read` — dep-update PR is opened via `VAULT_ECO_GITHUB_TOKEN`, not the default token |
| `go-checks.yaml` | `go-checks.yaml@main` | `contents: read` |
| `jira.yaml` | `jira.yaml@main` | `contents: read` + `issues: read` + `pull-requests: read` — Jira mirror writes via `JIRA_SYNC_API_TOKEN` |
| `tests.yaml` | `tests.yaml@main` | `contents: read` |

YAML validated locally with `yaml.safe_load`.