### PR TITLE
[CHANGELOG] Prepare for v0.23.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.23.3
+### May 13, 2026
+
+* updated dependencies (#399)
+* Backport #381 to 1.19.x : Add kid-based cache for multi-JWKS authentication (#387)
+* allow optional access token to be used to fetch additional groups (#329) (#341)
+* [Vault 1.19] update to go 1.23.8 and deps (#333)
+
 ## v0.26.2
 ### May 7, 2026
 


### PR DESCRIPTION
Changelog update for version [v0.23.3](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.23.3).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/25806829886

