### PR TITLE
VAULT-44835 [CHANGELOG] Prepare for v0.24.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.24.2
+### May 13, 2026
+
+* updated dependencies (#398)
+* Backport #381 to 1.20.x : Add kid-based cache for multi-JWKS authentication (#388)
+
 ## v0.26.2
 ### May 7, 2026
 


### PR DESCRIPTION
Jira: [VAULT-44835](https://hashicorp.atlassian.net/browse/VAULT-44835)

Changelog update for version [v0.24.2](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.24.2).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/25807515992



[VAULT-44835]: https://hashicorp.atlassian.net/browse/VAULT-44835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ