### PR TITLE
Adding Okta Provider for fetching all the groups from admin okta API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES:
+* **Okta Provider**: Add Okta provider with group fetching from Admin API when `fetch_groups=true` and truncation is detected.
+
 ## v0.26.2
 ### May 7, 2026
 

--- a/provider_config.go
+++ b/provider_config.go
@@ -21,6 +21,7 @@ func ProviderMap() map[string]CustomProvider {
 		"gsuite":     &GSuiteProvider{},
 		"secureauth": &SecureAuthProvider{},
 		"ibmisam":    &IBMISAMProvider{},
+		"okta":       &OktaProvider{},
 	}
 }
 

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -1,0 +1,285 @@
+package jwtauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// defaultOktaGroupsCap is Okta's default ID-token groups-claim
+	// truncation threshold. When a user belongs to more groups than
+	// this, Okta drops groups silently rather than aggregating
+	// distributed claims. Configurable per Okta authorization server;
+	// override via provider_config.groups_cap.
+	defaultOktaGroupsCap = 100
+
+	// oktaUserGroupsPathFmt is the Okta admin API path that returns
+	// the groups a user belongs to. The {user} segment accepts an
+	// Okta user id, login (email/UPN), or unique login shortname.
+	oktaUserGroupsPathFmt = "/api/v1/users/%s/groups"
+)
+
+// OktaProvider returns the full set of Okta groups a user belongs to
+// when Okta has truncated the id-token's groups claim. It calls Okta's
+// admin endpoint
+//
+//	GET /api/v1/users/{user}/groups
+//
+// authenticated with a configured Okta API token (SSWS), following
+// RFC 5988 Link-header pagination.
+//
+// This endpoint is admin-only and cannot be reached with an end-user
+// OAuth token regardless of okta.* scopes. The provider therefore
+// requires an Okta API token bound to a user with permission to read
+// users and read groups (a least-privilege custom admin role granting
+// "View users and their details" and "View groups and their details"
+// is sufficient). The token is supplied via provider_config.api_token
+// and is masked from config reads.
+type OktaProvider struct {
+	ctx    context.Context
+	config OktaProviderConfig
+
+	// groupsFilter is the compiled form of OktaProviderConfig.GroupsFilter.
+	// Nil when no filter is configured.
+	groupsFilter *regexp.Regexp
+}
+
+// OktaProviderConfig is decoded from jwtConfig.ProviderConfig during
+// Initialize.
+type OktaProviderConfig struct {
+	// OrgURL is the Okta org base URL, e.g. https://example.okta.com.
+	// Must use https.
+	OrgURL string `mapstructure:"org_url"`
+
+	// APIToken is an Okta API token (SSWS) used to authenticate the
+	// server-side groups lookup. Required.
+	APIToken string `mapstructure:"api_token"`
+
+	// UserIDClaim names the claim in the OIDC token whose value
+	// identifies the user to Okta. The value must be one of: the
+	// user's Okta id, login (email/UPN), or unique login shortname.
+	// Optional; when empty, the role's user_claim is used.
+	UserIDClaim string `mapstructure:"user_id_claim"`
+
+	// GroupsCap is the Okta id-token groups truncation threshold. When
+	// the groups claim is present with length >= GroupsCap, the
+	// provider treats it as truncated and re-fetches the full list
+	// via the admin API. Defaults to 100.
+	GroupsCap int `mapstructure:"groups_cap"`
+
+	// GroupsFilter is an optional Go regular expression. When
+	// non-empty, only groups whose name matches the pattern are
+	// returned to Vault. Applied identically to both the id-token
+	// claim path and the API fallback path so behavior is consistent
+	// regardless of whether the user crossed GroupsCap. Empty (the
+	// default) disables filtering; every group Okta returns passes
+	// through.
+	GroupsFilter string `mapstructure:"groups_filter"`
+}
+
+// Initialize validates and stores provider configuration. Satisfies
+// the CustomProvider interface.
+func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
+	var cfg OktaProviderConfig
+	if err := mapstructure.Decode(jc.ProviderConfig, &cfg); err != nil {
+		return err
+	}
+	if cfg.OrgURL == "" {
+		return errors.New("'org_url' must be set in provider_config for the okta provider")
+	}
+	u, err := url.Parse(cfg.OrgURL)
+	if err != nil {
+		return fmt.Errorf("invalid org_url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return errors.New("org_url must use https")
+	}
+	if cfg.APIToken == "" {
+		return errors.New("'api_token' must be set in provider_config for the okta provider")
+	}
+	if cfg.GroupsCap < 0 {
+		return errors.New("groups_cap must be >= 0")
+	}
+	if cfg.GroupsCap == 0 {
+		cfg.GroupsCap = defaultOktaGroupsCap
+	}
+	if cfg.GroupsFilter != "" {
+		re, err := regexp.Compile(cfg.GroupsFilter)
+		if err != nil {
+			return fmt.Errorf("invalid groups_filter regex: %w", err)
+		}
+		o.groupsFilter = re
+	}
+	o.config = cfg
+	return nil
+}
+
+// SensitiveKeys returns fields that must be masked when reading the
+// provider config back. Satisfies the CustomProvider interface.
+func (o *OktaProvider) SensitiveKeys() []string {
+	return []string{"api_token"}
+}
+
+// FetchGroups implements GroupsFetcher. Returns the id-token groups
+// claim when it's clearly untruncated; otherwise calls the Okta
+// admin API using the configured SSWS token. When groups_filter is
+// set, both paths return only the subset of group names matching the
+// configured regex.
+func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
+	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
+
+	if groupsClaimRaw != nil {
+		if list, ok := normalizeList(groupsClaimRaw); ok && len(list) < o.config.GroupsCap {
+			if o.groupsFilter == nil {
+				return groupsClaimRaw, nil
+			}
+			return o.applyGroupsFilter(b, list), nil
+		}
+	}
+
+	userID, err := o.resolveUserID(b, allClaims, role)
+	if err != nil {
+		return nil, err
+	}
+
+	o.ctx, err = b.createCAContext(b.providerCtx, b.cachedConfig.OIDCDiscoveryCAPEM)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create CA context: %w", err)
+	}
+
+	groups, err := o.getOktaGroups(userID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch groups from Okta API: %w", err)
+	}
+	b.Logger().Debug("groups fetched from Okta API", "count", len(groups))
+	if o.groupsFilter != nil {
+		groups = o.applyGroupsFilter(b, groups)
+	}
+	return groups, nil
+}
+
+// resolveUserID returns the value of the configured user_id_claim, or
+// the role's user_claim if user_id_claim is unset. Must be a string
+// that Okta accepts as a user identifier.
+func (o *OktaProvider) resolveUserID(b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole) (string, error) {
+	claim := o.config.UserIDClaim
+	if claim == "" {
+		claim = role.UserClaim
+	}
+	if claim == "" {
+		return "", errors.New("user_id_claim is unset and role has no user_claim")
+	}
+	raw := getClaim(b.Logger(), allClaims, claim)
+	if raw == nil {
+		return "", fmt.Errorf("unable to locate %q in claims for Okta user lookup", claim)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("claim %q is not a string; cannot use for Okta user lookup", claim)
+	}
+	if s == "" {
+		return "", fmt.Errorf("claim %q is empty; cannot use for Okta user lookup", claim)
+	}
+	return s, nil
+}
+
+// applyGroupsFilter returns the subset of list whose elements are
+// strings matching o.groupsFilter. Non-string entries are dropped.
+// Caller must only invoke this when groupsFilter is non-nil.
+func (o *OktaProvider) applyGroupsFilter(b *jwtAuthBackend, list []interface{}) []interface{} {
+	out := make([]interface{}, 0, len(list))
+	for _, item := range list {
+		s, ok := item.(string)
+		if !ok {
+			continue
+		}
+		if o.groupsFilter.MatchString(s) {
+			out = append(out, s)
+		}
+	}
+	b.Logger().Debug("groups filter applied", "before", len(list), "after", len(out))
+	return out
+}
+
+// getOktaGroups fetches every group the named user belongs to from
+// /api/v1/users/{userID}/groups, following RFC 5988 Link-header
+// pagination. Authenticated with the configured admin API token.
+func (o *OktaProvider) getOktaGroups(userID string) ([]interface{}, error) {
+	client := http.DefaultClient
+	if c, ok := o.ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		client = c
+	}
+
+	next := strings.TrimRight(o.config.OrgURL, "/") + fmt.Sprintf(oktaUserGroupsPathFmt, url.PathEscape(userID))
+
+	var all []interface{}
+	for next != "" {
+		req, err := http.NewRequest("GET", next, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error constructing groups request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "SSWS "+o.config.APIToken)
+
+		res, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("unable to call Okta API: %w", err)
+		}
+		body, readErr := io.ReadAll(res.Body)
+		res.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read Okta API response: %w", readErr)
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("okta api returned %d: %s", res.StatusCode, string(body))
+		}
+
+		var page []oktaGroup
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("unable to decode Okta API response: %w", err)
+		}
+		for _, g := range page {
+			if g.Profile.Name != "" {
+				all = append(all, g.Profile.Name)
+			}
+		}
+		next = nextLink(res.Header.Values("Link"))
+	}
+
+	return all, nil
+}
+
+// oktaGroup is a partial shape of Okta's Group resource.
+type oktaGroup struct {
+	ID      string           `json:"id"`
+	Profile oktaGroupProfile `json:"profile"`
+}
+
+type oktaGroupProfile struct {
+	Name string `json:"name"`
+}
+
+// linkNextRE matches the URL in a Link header entry whose rel="next",
+// per RFC 5988, e.g. <https://example.okta.com/...>; rel="next".
+var linkNextRE = regexp.MustCompile(`<([^>]+)>\s*;\s*rel\s*=\s*"next"`)
+
+// nextLink returns the URL of the rel="next" link from a slice of
+// Link header values, or "" if none is present.
+func nextLink(headers []string) string {
+	for _, h := range headers {
+		if m := linkNextRE.FindStringSubmatch(h); m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -34,7 +34,7 @@ const (
 	// maxOktaPages is the maximum number of paginated API responses
 	// getOktaGroups will follow before aborting. Guards against
 	// infinite loops caused by a circular or malformed Link header.
-	maxOktaPages = 100
+	maxOktaPages = 200
 )
 
 // OktaProvider returns the full set of Okta groups a user belongs to

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -30,8 +30,8 @@ const (
 )
 
 // OktaProvider returns the full set of Okta groups a user belongs to
-// when Okta has truncated the id-token's groups claim. It calls Okta's
-// admin endpoint
+// when Okta has truncated the id-token's groups claim. When fetch_groups
+// is enabled (default), it calls Okta's admin endpoint
 //
 //	GET /api/v1/users/{user}/groups
 //
@@ -39,12 +39,16 @@ const (
 // RFC 5988 Link-header pagination.
 //
 // This endpoint is admin-only and cannot be reached with an end-user
-// OAuth token regardless of okta.* scopes. The provider therefore
-// requires an Okta API token bound to a user with permission to read
-// users and read groups (a least-privilege custom admin role granting
-// "View users and their details" and "View groups and their details"
-// is sufficient). The token is supplied via provider_config.api_token
+// OAuth token regardless of okta.* scopes. When fetch_groups is enabled,
+// the provider requires an Okta API token bound to a user with permission
+// to read users and read groups (a least-privilege custom admin role
+// granting "View users and their details" and "View groups and their
+// details" is sufficient). The token is supplied via provider_config.api_token
 // and is masked from config reads.
+//
+// When fetch_groups is disabled, the provider uses only the groups from
+// the ID token, which may be incomplete if the user belongs to more groups
+// than the configured groups_cap threshold.
 type OktaProvider struct {
 	ctx    context.Context
 	config OktaProviderConfig
@@ -58,11 +62,12 @@ type OktaProvider struct {
 // Initialize.
 type OktaProviderConfig struct {
 	// OrgURL is the Okta org base URL, e.g. https://example.okta.com.
-	// Must use https.
+	// Must use https. Optional; if not provided, will be derived from
+	// oidc_discovery_url.
 	OrgURL string `mapstructure:"org_url"`
 
 	// APIToken is an Okta API token (SSWS) used to authenticate the
-	// server-side groups lookup. Required.
+	// server-side groups lookup. Required when FetchGroups is true.
 	APIToken string `mapstructure:"api_token"`
 
 	// UserIDClaim names the claim in the OIDC token whose value
@@ -85,6 +90,12 @@ type OktaProviderConfig struct {
 	// default) disables filtering; every group Okta returns passes
 	// through.
 	GroupsFilter string `mapstructure:"groups_filter"`
+
+	// FetchGroups controls whether to fetch groups from Okta Admin API.
+	// When true, groups at or above GroupsCap will trigger an API call.
+	// When false (the default when the key is absent), always uses groups
+	// from the ID token. Must be explicitly set to true to enable API fetching.
+	FetchGroups bool `mapstructure:"fetch_groups"`
 }
 
 // Initialize validates and stores provider configuration. Satisfies
@@ -94,7 +105,15 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 	if err := mapstructure.Decode(jc.ProviderConfig, &cfg); err != nil {
 		return err
 	}
-	// Validate org_url if provided
+
+	// Auto-derive org_url from oidc_discovery_url if not provided
+	if cfg.OrgURL == "" && jc.OIDCDiscoveryURL != "" {
+		if u, err := url.Parse(jc.OIDCDiscoveryURL); err == nil {
+			cfg.OrgURL = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		}
+	}
+
+	// Validate org_url if provided or derived
 	if cfg.OrgURL != "" {
 		u, err := url.Parse(cfg.OrgURL)
 		if err != nil {
@@ -104,7 +123,19 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 			return errors.New("org_url must use https")
 		}
 	}
-	// api_token validation is deferred to FetchGroups when actually needed
+
+	// Validate credentials if fetch_groups is enabled
+	if cfg.FetchGroups {
+		// org_url should be available either explicitly or auto-derived
+		// Only fail if it's still empty after auto-derivation attempt
+		if cfg.OrgURL == "" {
+			return errors.New("'org_url' must be set in provider_config or oidc_discovery_url must be configured when fetch_groups=true")
+		}
+		if cfg.APIToken == "" {
+			return errors.New("'api_token' is required in provider_config when fetch_groups=true")
+		}
+	}
+
 	if cfg.GroupsCap < 0 {
 		return errors.New("groups_cap must be >= 0")
 	}
@@ -136,8 +167,26 @@ func (o *OktaProvider) SensitiveKeys() []string {
 func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
 	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
 
+	// If fetch_groups is disabled, always use groups from token
+	if !o.config.FetchGroups {
+		if groupsClaimRaw == nil {
+			return nil, fmt.Errorf("%q claim not found in token", role.GroupsClaim)
+		}
+
+		// Apply filter if configured
+		if o.groupsFilter != nil {
+			if list, ok := normalizeList(groupsClaimRaw); ok {
+				return o.applyGroupsFilter(b, list), nil
+			}
+		}
+
+		return groupsClaimRaw, nil
+	}
+
+	// fetch_groups is enabled - check for truncation
 	if groupsClaimRaw != nil {
 		if list, ok := normalizeList(groupsClaimRaw); ok && len(list) < o.config.GroupsCap {
+			// Definitely NOT truncated - use token groups
 			if o.groupsFilter == nil {
 				return groupsClaimRaw, nil
 			}
@@ -145,13 +194,8 @@ func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClai
 		}
 	}
 
-	// Validate required config before making API call
-	if o.config.OrgURL == "" {
-		return nil, errors.New("'org_url' must be set in provider_config to fetch groups from Okta API")
-	}
-	if o.config.APIToken == "" {
-		return nil, errors.New("'api_token' must be set in provider_config to fetch groups from Okta API")
-	}
+	// Groups might be truncated (len >= groups_cap) or missing
+	// Fetch from API (credentials already validated in Initialize)
 
 	userID, err := o.resolveUserID(b, allClaims, role)
 	if err != nil {

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
 package jwtauth
 
 import (

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -30,6 +30,11 @@ const (
 	// the groups a user belongs to. The {user} segment accepts an
 	// Okta user id, login (email/UPN), or unique login shortname.
 	oktaUserGroupsPathFmt = "/api/v1/users/%s/groups"
+
+	// maxOktaPages is the maximum number of paginated API responses
+	// getOktaGroups will follow before aborting. Guards against
+	// infinite loops caused by a circular or malformed Link header.
+	maxOktaPages = 100
 )
 
 // OktaProvider returns the full set of Okta groups a user belongs to
@@ -53,10 +58,11 @@ const (
 // the ID token, which may be incomplete if the user belongs to more groups
 // than the configured groups_cap threshold.
 type OktaProvider struct {
-	ctx    context.Context
 	config OktaProviderConfig
 
 	// groupsFilter is the compiled form of OktaProviderConfig.GroupsFilter.
+	// It is stored separately from OktaProviderConfig because *regexp.Regexp
+	// cannot be decoded by mapstructure and must be compiled after decoding.
 	// Nil when no filter is configured.
 	groupsFilter *regexp.Regexp
 }
@@ -148,14 +154,19 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 	if cfg.GroupsCap == 0 {
 		cfg.GroupsCap = defaultOktaGroupsCap
 	}
+
+	var groupsFilter *regexp.Regexp
 	if cfg.GroupsFilter != "" {
 		re, err := regexp.Compile(cfg.GroupsFilter)
 		if err != nil {
 			return fmt.Errorf("invalid groups_filter regex: %w", err)
 		}
-		o.groupsFilter = re
+		groupsFilter = re
 	}
+
+	// All validation passed — update provider state atomically.
 	o.config = cfg
+	o.groupsFilter = groupsFilter
 	return nil
 }
 
@@ -170,7 +181,7 @@ func (o *OktaProvider) SensitiveKeys() []string {
 // admin API using the configured SSWS token. When groups_filter is
 // set, both paths return only the subset of group names matching the
 // configured regex.
-func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
+func (o *OktaProvider) FetchGroups(ctx context.Context, b *jwtAuthBackend, allClaims map[string]interface{}, role *jwtRole, _ oauth2.TokenSource) (interface{}, error) {
 	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
 
 	// If fetch_groups is disabled, always use groups from token
@@ -208,12 +219,16 @@ func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClai
 		return nil, err
 	}
 
-	o.ctx, err = b.createCAContext(b.providerCtx, b.cachedConfig.OIDCDiscoveryCAPEM)
+	apiCtx, err := b.createCAContext(b.providerCtx, b.cachedConfig.OIDCDiscoveryCAPEM)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create CA context: %w", err)
 	}
+	client := http.DefaultClient
+	if c, ok := apiCtx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		client = c
+	}
 
-	groups, err := o.getOktaGroups(userID)
+	groups, err := o.getOktaGroups(ctx, client, userID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch groups from Okta API: %w", err)
 	}
@@ -270,17 +285,17 @@ func (o *OktaProvider) applyGroupsFilter(b *jwtAuthBackend, list []interface{}) 
 // getOktaGroups fetches every group the named user belongs to from
 // /api/v1/users/{userID}/groups, following RFC 5988 Link-header
 // pagination. Authenticated with the configured admin API token.
-func (o *OktaProvider) getOktaGroups(userID string) ([]interface{}, error) {
-	client := http.DefaultClient
-	if c, ok := o.ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
-		client = c
-	}
-
+// ctx is the login request context; cancellation and deadlines are propagated
+// to every HTTP request.
+func (o *OktaProvider) getOktaGroups(ctx context.Context, client *http.Client, userID string) ([]interface{}, error) {
 	next := strings.TrimRight(o.config.OrgURL, "/") + fmt.Sprintf(oktaUserGroupsPathFmt, url.PathEscape(userID))
 
 	var all []interface{}
-	for next != "" {
-		req, err := http.NewRequest("GET", next, nil)
+	for page := 0; next != ""; page++ {
+		if page >= maxOktaPages {
+			return nil, fmt.Errorf("okta API pagination exceeded %d pages; possible circular Link header", maxOktaPages)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing groups request: %w", err)
 		}

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -94,19 +94,17 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 	if err := mapstructure.Decode(jc.ProviderConfig, &cfg); err != nil {
 		return err
 	}
-	if cfg.OrgURL == "" {
-		return errors.New("'org_url' must be set in provider_config for the okta provider")
+	// Validate org_url if provided
+	if cfg.OrgURL != "" {
+		u, err := url.Parse(cfg.OrgURL)
+		if err != nil {
+			return fmt.Errorf("invalid org_url: %w", err)
+		}
+		if u.Scheme != "https" {
+			return errors.New("org_url must use https")
+		}
 	}
-	u, err := url.Parse(cfg.OrgURL)
-	if err != nil {
-		return fmt.Errorf("invalid org_url: %w", err)
-	}
-	if u.Scheme != "https" {
-		return errors.New("org_url must use https")
-	}
-	if cfg.APIToken == "" {
-		return errors.New("'api_token' must be set in provider_config for the okta provider")
-	}
+	// api_token validation is deferred to FetchGroups when actually needed
 	if cfg.GroupsCap < 0 {
 		return errors.New("groups_cap must be >= 0")
 	}
@@ -145,6 +143,14 @@ func (o *OktaProvider) FetchGroups(_ context.Context, b *jwtAuthBackend, allClai
 			}
 			return o.applyGroupsFilter(b, list), nil
 		}
+	}
+
+	// Validate required config before making API call
+	if o.config.OrgURL == "" {
+		return nil, errors.New("'org_url' must be set in provider_config to fetch groups from Okta API")
+	}
+	if o.config.APIToken == "" {
+		return nil, errors.New("'api_token' must be set in provider_config to fetch groups from Okta API")
 	}
 
 	userID, err := o.resolveUserID(b, allClaims, role)

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -34,7 +34,7 @@ const (
 
 // OktaProvider returns the full set of Okta groups a user belongs to
 // when Okta has truncated the id-token's groups claim. When fetch_groups
-// is enabled (default), it calls Okta's admin endpoint
+// is enabled, it calls Okta's admin endpoint
 //
 //	GET /api/v1/users/{user}/groups
 //
@@ -124,6 +124,9 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 		}
 		if u.Scheme != "https" {
 			return errors.New("org_url must use https")
+		}
+		if u.Host == "" {
+			return errors.New("org_url must include a host")
 		}
 	}
 

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -134,6 +134,9 @@ func (o *OktaProvider) Initialize(_ context.Context, jc *jwtConfig) error {
 		if u.Host == "" {
 			return errors.New("org_url must include a host")
 		}
+		// Strip any path/query/fragment — org_url must be scheme://host only.
+		// A path is often present when someone copies oidc_discovery_url
+		cfg.OrgURL = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	}
 
 	// Validate credentials if fetch_groups is enabled

--- a/provider_okta.go
+++ b/provider_okta.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jwtauth

--- a/provider_okta_test.go
+++ b/provider_okta_test.go
@@ -1,0 +1,1159 @@
+package jwtauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"golang.org/x/oauth2"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+// newOktaTestBackend returns a minimal jwtAuthBackend suitable for unit tests.
+// It does not connect to Vault storage or a real OIDC server.
+func newOktaTestBackend(t *testing.T) *jwtAuthBackend {
+	t.Helper()
+	b := &jwtAuthBackend{
+		Backend:     &framework.Backend{},
+		providerCtx: context.Background(),
+		cachedConfig: &jwtConfig{
+			OIDCDiscoveryCAPEM: "",
+		},
+	}
+	return b
+}
+
+// newOktaRole returns a minimal jwtRole for use in FetchGroups tests.
+func newOktaRole(groupsClaim, userClaim string) *jwtRole {
+	return &jwtRole{
+		GroupsClaim: groupsClaim,
+		UserClaim:   userClaim,
+	}
+}
+
+// oktaGroupJSON returns a JSON array of Okta group objects for use in mock
+// server responses.
+func oktaGroupJSON(names ...string) string {
+	type profile struct {
+		Name string `json:"name"`
+	}
+	type group struct {
+		ID      string  `json:"id"`
+		Profile profile `json:"profile"`
+	}
+	groups := make([]group, len(names))
+	for i, n := range names {
+		groups[i] = group{ID: fmt.Sprintf("id-%d", i), Profile: profile{Name: n}}
+	}
+	b, _ := json.Marshal(groups)
+	return string(b)
+}
+
+// buildJWTConfig builds a jwtConfig map suitable for passing to Initialize.
+func buildJWTConfig(orgURL string, extra map[string]interface{}) *jwtConfig {
+	pc := map[string]interface{}{
+		"provider":  "okta",
+		"api_token": "test-token",
+	}
+	if orgURL != "" {
+		pc["org_url"] = orgURL
+	}
+	for k, v := range extra {
+		pc[k] = v
+	}
+	return &jwtConfig{
+		OIDCDiscoveryURL: "https://example.okta.com",
+		ProviderConfig:   pc,
+	}
+}
+
+// ---- Initialize tests -------------------------------------------------------
+
+func TestOktaProvider_Initialize_Valid(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", nil)
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.OrgURL != "https://example.okta.com" {
+		t.Errorf("expected org_url to be set, got %q", p.config.OrgURL)
+	}
+	if p.config.GroupsCap != defaultOktaGroupsCap {
+		t.Errorf("expected default GroupsCap %d, got %d", defaultOktaGroupsCap, p.config.GroupsCap)
+	}
+	// fetch_groups not in map → should default to false
+	if p.config.FetchGroups {
+		t.Error("expected FetchGroups to default to false when key absent")
+	}
+}
+
+func TestOktaProvider_Initialize_MissingOrgURL_DerivedFromDiscoveryURL(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("", nil) // no org_url — should be derived
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.OrgURL != "https://example.okta.com" {
+		t.Errorf("expected org_url derived as https://example.okta.com, got %q", p.config.OrgURL)
+	}
+}
+
+func TestOktaProvider_Initialize_OrgURLDerivedStripsPath(t *testing.T) {
+	// Custom auth server: discovery URL has /oauth2/... path that must be stripped
+	p := &OktaProvider{}
+	jc := buildJWTConfig("", nil)
+	jc.OIDCDiscoveryURL = "https://example.okta.com/oauth2/aus1abc123"
+	delete(jc.ProviderConfig, "org_url")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.OrgURL != "https://example.okta.com" {
+		t.Errorf("expected path stripped, got %q", p.config.OrgURL)
+	}
+}
+
+func TestOktaProvider_Initialize_MissingAPIToken_FetchGroupsTrue(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups": true,
+	})
+	delete(jc.ProviderConfig, "api_token")
+	err := p.Initialize(context.Background(), jc)
+	if err == nil {
+		t.Fatal("expected error for missing api_token with fetch_groups=true")
+	}
+	if !strings.Contains(err.Error(), "api_token") {
+		t.Errorf("expected error to mention api_token, got: %v", err)
+	}
+}
+
+func TestOktaProvider_Initialize_MissingAPIToken_FetchGroupsFalse(t *testing.T) {
+	// When fetch_groups=false, api_token is not required
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups": false,
+	})
+	delete(jc.ProviderConfig, "api_token")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error when fetch_groups=false and api_token missing: %v", err)
+	}
+}
+
+func TestOktaProvider_Initialize_NonHTTPSOrgURL(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("http://example.okta.com", nil) // http not https
+	err := p.Initialize(context.Background(), jc)
+	if err == nil {
+		t.Fatal("expected error for non-https org_url")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("expected error to mention https, got: %v", err)
+	}
+}
+
+func TestOktaProvider_Initialize_InvalidGroupsCap(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_cap": -1,
+	})
+	err := p.Initialize(context.Background(), jc)
+	if err == nil {
+		t.Fatal("expected error for negative groups_cap")
+	}
+}
+
+func TestOktaProvider_Initialize_GroupsCapZeroDefaultsTo100(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_cap": 0,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.GroupsCap != defaultOktaGroupsCap {
+		t.Errorf("expected GroupsCap=%d when 0 supplied, got %d", defaultOktaGroupsCap, p.config.GroupsCap)
+	}
+}
+
+func TestOktaProvider_Initialize_InvalidGroupsFilter(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": "[invalid",
+	})
+	err := p.Initialize(context.Background(), jc)
+	if err == nil {
+		t.Fatal("expected error for invalid groups_filter regex")
+	}
+	if !strings.Contains(err.Error(), "groups_filter") {
+		t.Errorf("expected error to mention groups_filter, got: %v", err)
+	}
+}
+
+func TestOktaProvider_Initialize_ValidGroupsFilter(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": "^vault-",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.groupsFilter == nil {
+		t.Error("expected groupsFilter to be compiled")
+	}
+}
+
+func TestOktaProvider_Initialize_FetchGroupsExplicitFalse(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups": false,
+	})
+	delete(jc.ProviderConfig, "api_token")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.FetchGroups {
+		t.Error("expected FetchGroups=false when explicitly set to false")
+	}
+}
+
+// ---- SensitiveKeys tests ----------------------------------------------------
+
+func TestOktaProvider_SensitiveKeys(t *testing.T) {
+	p := &OktaProvider{}
+	keys := p.SensitiveKeys()
+	if len(keys) != 1 || keys[0] != "api_token" {
+		t.Errorf("expected SensitiveKeys=[api_token], got %v", keys)
+	}
+}
+
+// ---- FetchGroups — fetch_groups=false path ----------------------------------
+
+func TestOktaProvider_FetchGroups_FetchGroupsDisabled_UsesToken(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups": false,
+	})
+	delete(jc.ProviderConfig, "api_token")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"g1", "g2", "g3"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{}, got %T", result)
+	}
+	if len(groups) != 3 {
+		t.Errorf("expected 3 groups, got %d", len(groups))
+	}
+}
+
+func TestOktaProvider_FetchGroups_FetchGroupsDisabled_MissingClaim_Error(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups": false,
+	})
+	delete(jc.ProviderConfig, "api_token")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub": "user@example.com",
+		// no groups claim
+	}
+
+	_, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err == nil {
+		t.Fatal("expected error when groups claim missing and fetch_groups=false")
+	}
+}
+
+func TestOktaProvider_FetchGroups_FetchGroupsDisabled_FilterApplied(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"fetch_groups":  false,
+		"groups_filter": "^vault-",
+	})
+	delete(jc.ProviderConfig, "api_token")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"vault-admin", "corp-everyone", "vault-readonly"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups := result.([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("expected 2 filtered groups, got %d: %v", len(groups), groups)
+	}
+	for _, g := range groups {
+		if !strings.HasPrefix(g.(string), "vault-") {
+			t.Errorf("expected only vault- groups, got %q", g)
+		}
+	}
+}
+
+// ---- FetchGroups — fast path (below cap, no API call) -----------------------
+
+func TestOktaProvider_FetchGroups_FastPath_BelowCap_NoAPICall(t *testing.T) {
+	// Mock server that should NOT be called
+	called := false
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"groups_cap":   5,
+		"fetch_groups": true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	role := newOktaRole("groups", "sub")
+	// 3 groups < cap of 5 → fast path
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"g1", "g2", "g3"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("API should not have been called on fast path")
+	}
+	_ = result
+}
+
+func TestOktaProvider_FetchGroups_FastPath_WithFilter_NoAPICall(t *testing.T) {
+	called := false
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"groups_cap":    5,
+		"groups_filter": "^vault-",
+		"fetch_groups":  true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"vault-admin", "corp-all", "vault-readonly"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("API should not have been called on fast path")
+	}
+	groups := result.([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("expected 2 filtered groups, got %d", len(groups))
+	}
+}
+
+// ---- FetchGroups — API fallback (at or above cap) ---------------------------
+
+func TestOktaProvider_FetchGroups_AtCap_TriggersAPI(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/api/v1/users/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3", "g4", "g5"))
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	p.ctx = context.Background()
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"groups_cap":   3,
+		"fetch_groups": true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
+	role := newOktaRole("groups", "sub")
+	// exactly 3 groups == cap → fallback
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"x", "y", "z"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups := result.([]interface{})
+	if len(groups) != 5 {
+		t.Errorf("expected 5 groups from API, got %d", len(groups))
+	}
+}
+
+func TestOktaProvider_FetchGroups_ClaimAbsent_TriggersAPI(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, oktaGroupJSON("vault-admin"))
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	p.ctx = context.Background()
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"fetch_groups": true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
+	role := newOktaRole("groups", "sub")
+	// no groups claim at all → fallback
+	claims := map[string]interface{}{
+		"sub": "user@example.com",
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups := result.([]interface{})
+	if len(groups) != 1 || groups[0] != "vault-admin" {
+		t.Errorf("unexpected groups from API: %v", groups)
+	}
+}
+
+func TestOktaProvider_FetchGroups_AboveCap_TriggersAPI(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, oktaGroupJSON("full-g1", "full-g2"))
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	p.ctx = context.Background()
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"groups_cap":   2,
+		"fetch_groups": true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
+	role := newOktaRole("groups", "sub")
+	// 3 groups > cap of 2 → fallback
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": []interface{}{"a", "b", "c"},
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups := result.([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("expected 2 groups from API, got %d", len(groups))
+	}
+}
+
+func TestOktaProvider_FetchGroups_APIFallback_WithFilter(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, oktaGroupJSON("vault-admin", "corp-all", "vault-readonly", "ad-sync-group"))
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	p.ctx = context.Background()
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"groups_filter": "^vault-",
+		"fetch_groups":  true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
+	role := newOktaRole("groups", "sub")
+	// no groups claim → API fallback
+	claims := map[string]interface{}{
+		"sub": "user@example.com",
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	groups := result.([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("expected 2 filtered groups, got %d: %v", len(groups), groups)
+	}
+	for _, g := range groups {
+		if !strings.HasPrefix(g.(string), "vault-") {
+			t.Errorf("expected only vault- groups, got %q", g)
+		}
+	}
+}
+
+func TestOktaProvider_FetchGroups_EmptyAPIResult_NoError(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "[]")
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{}
+	p.ctx = context.Background()
+	jc := buildJWTConfig(ts.URL, map[string]interface{}{
+		"fetch_groups": true,
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
+	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub": "user@example.com",
+	}
+
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty group list: %v", err)
+	}
+	groups, ok := result.([]interface{})
+	if !ok {
+		// nil result is also acceptable for empty list
+		return
+	}
+	if len(groups) != 0 {
+		t.Errorf("expected empty groups list, got %v", groups)
+	}
+}
+
+// ---- resolveUserID tests ----------------------------------------------------
+
+func TestOktaProvider_ResolveUserID_FromUserIDClaim(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"user_id_claim": "email",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub":   "00u1abc",
+		"email": "user@example.com",
+	}
+
+	id, err := p.resolveUserID(b, claims, role)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "user@example.com" {
+		t.Errorf("expected user@example.com, got %q", id)
+	}
+}
+
+func TestOktaProvider_ResolveUserID_FallsBackToRoleUserClaim(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", nil) // no user_id_claim
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub") // role.UserClaim = "sub"
+	claims := map[string]interface{}{
+		"sub": "00u1abc",
+	}
+
+	id, err := p.resolveUserID(b, claims, role)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "00u1abc" {
+		t.Errorf("expected 00u1abc, got %q", id)
+	}
+}
+
+func TestOktaProvider_ResolveUserID_ClaimNotInToken_Error(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"user_id_claim": "email",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub": "00u1abc",
+		// email claim absent
+	}
+
+	_, err := p.resolveUserID(b, claims, role)
+	if err == nil {
+		t.Fatal("expected error when user_id_claim not found in token")
+	}
+	if !strings.Contains(err.Error(), "email") {
+		t.Errorf("expected error to mention claim name, got: %v", err)
+	}
+}
+
+func TestOktaProvider_ResolveUserID_ClaimNotString_Error(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"user_id_claim": "sub",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+	claims := map[string]interface{}{
+		"sub": 12345, // not a string
+	}
+
+	_, err := p.resolveUserID(b, claims, role)
+	if err == nil {
+		t.Fatal("expected error when claim value is not a string")
+	}
+}
+
+func TestOktaProvider_ResolveUserID_BothClaimsUnset_Error(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", nil) // no user_id_claim
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "") // role.UserClaim also empty
+	claims := map[string]interface{}{
+		"sub": "00u1abc",
+	}
+
+	_, err := p.resolveUserID(b, claims, role)
+	if err == nil {
+		t.Fatal("expected error when both user_id_claim and role.UserClaim are empty")
+	}
+}
+
+// ---- getOktaGroups pagination tests -----------------------------------------
+
+func TestOktaProvider_GetOktaGroups_SinglePage(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// no Link header → single page
+		fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3"))
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	groups, err := p.getOktaGroups("user@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 3 {
+		t.Errorf("expected 3 groups, got %d", len(groups))
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_MultiPage_PaginationFollowed(t *testing.T) {
+	page := 0
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		page++
+		switch page {
+		case 1:
+			// First page — include Link: rel="next"
+			w.Header().Set("Link", fmt.Sprintf(`<https://%s/api/v1/users/user%%40example.com/groups?after=cursor1&limit=200>; rel="next"`, r.Host))
+			fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3"))
+		case 2:
+			// Second page — no next link
+			fmt.Fprint(w, oktaGroupJSON("g4", "g5"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	groups, err := p.getOktaGroups("user@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 5 {
+		t.Errorf("expected 5 groups across 2 pages, got %d: %v", len(groups), groups)
+	}
+	if page != 2 {
+		t.Errorf("expected exactly 2 API calls, made %d", page)
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_API401_Error(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"errorCode":"E0000011","errorSummary":"Invalid token"}`)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "bad-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	_, err := p.getOktaGroups("user@example.com")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention 401, got: %v", err)
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_API403_Error(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"errorCode":"E0000006","errorSummary":"You do not have permission"}`)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "limited-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	_, err := p.getOktaGroups("user@example.com")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected error to mention 403, got: %v", err)
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_API500_Error(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	_, err := p.getOktaGroups("user@example.com")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_InvalidJSON_Error(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `not-valid-json`)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	_, err := p.getOktaGroups("user@example.com")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_EmptyProfileName_Dropped(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// one group has empty name — should be silently dropped
+		fmt.Fprint(w, `[
+			{"id":"id1","profile":{"name":"vault-admin"}},
+			{"id":"id2","profile":{"name":""}},
+			{"id":"id3","profile":{"name":"vault-readonly"}}
+		]`)
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	groups, err := p.getOktaGroups("user@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Errorf("expected 2 groups (empty name dropped), got %d: %v", len(groups), groups)
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_SSWSAuthHeader(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "[]")
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "my-ssws-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	_, _ = p.getOktaGroups("user@example.com")
+	expected := "SSWS my-ssws-token"
+	if gotAuth != expected {
+		t.Errorf("expected Authorization header %q, got %q", expected, gotAuth)
+	}
+}
+
+func TestOktaProvider_GetOktaGroups_UserIDPathEncoded(t *testing.T) {
+	var gotRequestURI string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RequestURI is the unmodified request-target as sent by the client,
+		// preserving any percent-encoding applied by url.PathEscape.
+		gotRequestURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "[]")
+	}))
+	defer ts.Close()
+
+	p := &OktaProvider{
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+		config: OktaProviderConfig{
+			OrgURL:      ts.URL,
+			APIToken:    "test-token",
+			FetchGroups: true,
+			GroupsCap:   defaultOktaGroupsCap,
+		},
+	}
+
+	// Use a user ID containing a space — url.PathEscape encodes it as %20.
+	_, _ = p.getOktaGroups("john doe")
+	if !strings.Contains(gotRequestURI, "john%20doe") {
+		t.Errorf("expected space percent-encoded as %%20 in request URI, got %q", gotRequestURI)
+	}
+}
+
+// ---- nextLink helper tests --------------------------------------------------
+
+func TestNextLink_Present(t *testing.T) {
+	headers := []string{
+		`<https://example.okta.com/api/v1/users/me/groups?after=cursor>; rel="next"`,
+	}
+	got := nextLink(headers)
+	want := "https://example.okta.com/api/v1/users/me/groups?after=cursor"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestNextLink_Absent(t *testing.T) {
+	headers := []string{
+		`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`,
+	}
+	got := nextLink(headers)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestNextLink_MultipleHeaders_ReturnsNext(t *testing.T) {
+	headers := []string{
+		`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`,
+		`<https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200>; rel="next"`,
+	}
+	got := nextLink(headers)
+	want := "https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestNextLink_Empty(t *testing.T) {
+	got := nextLink([]string{})
+	if got != "" {
+		t.Errorf("expected empty string for empty headers, got %q", got)
+	}
+}
+
+func TestNextLink_MalformedHeader(t *testing.T) {
+	headers := []string{"not-a-link-header"}
+	got := nextLink(headers)
+	if got != "" {
+		t.Errorf("expected empty string for malformed header, got %q", got)
+	}
+}
+
+// ---- applyGroupsFilter tests ------------------------------------------------
+
+func TestApplyGroupsFilter_MatchesSubset(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": "^vault-",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	list := []interface{}{"vault-admin", "corp-all", "vault-readonly", "ad-sync"}
+	result := p.applyGroupsFilter(b, list)
+	if len(result) != 2 {
+		t.Errorf("expected 2 matching groups, got %d: %v", len(result), result)
+	}
+}
+
+func TestApplyGroupsFilter_MatchesAll(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": ".*",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	list := []interface{}{"g1", "g2", "g3"}
+	result := p.applyGroupsFilter(b, list)
+	if len(result) != 3 {
+		t.Errorf("expected all 3 groups, got %d", len(result))
+	}
+}
+
+func TestApplyGroupsFilter_MatchesNone(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": "^nomatch-",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	list := []interface{}{"g1", "g2", "g3"}
+	result := p.applyGroupsFilter(b, list)
+	if len(result) != 0 {
+		t.Errorf("expected 0 matching groups, got %d", len(result))
+	}
+}
+
+func TestApplyGroupsFilter_NonStringEntriesDropped(t *testing.T) {
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
+		"groups_filter": ".*",
+	})
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	list := []interface{}{"valid-group", 123, nil, "another-group"}
+	result := p.applyGroupsFilter(b, list)
+	if len(result) != 2 {
+		t.Errorf("expected 2 string groups (non-strings dropped), got %d: %v", len(result), result)
+	}
+}
+
+// ---- backward compatibility test --------------------------------------------
+
+func TestOktaProvider_BackwardCompat_NoProviderConfig_GeneralFlowUnaffected(t *testing.T) {
+	// Verifies that OktaProvider is entirely opt-in: when provider_config is
+	// absent, ProviderMap returns nil and the general JWT flow runs unchanged.
+	pm := ProviderMap()
+	if pm["okta"] == nil {
+		t.Fatal("okta must be registered in ProviderMap")
+	}
+	// Absence of provider_config means NewProviderConfig returns (nil, nil)
+	// — tested at the framework level; here we just confirm registration.
+	p, ok := pm["okta"].(*OktaProvider)
+	if !ok {
+		t.Fatalf("expected *OktaProvider in ProviderMap, got %T", pm["okta"])
+	}
+	_ = p
+}
+
+func TestOktaProvider_BackwardCompat_FetchGroupsDefaultFalse(t *testing.T) {
+	// When fetch_groups key is absent from provider_config, it defaults to false.
+	// Existing configs without fetch_groups therefore use only token groups.
+	// fetch_groups must be explicitly set to true to enable API fetching.
+	p := &OktaProvider{}
+	jc := buildJWTConfig("https://example.okta.com", nil)
+	// Confirm key is absent
+	delete(jc.ProviderConfig, "fetch_groups")
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if p.config.FetchGroups {
+		t.Error("expected FetchGroups=false when key absent")
+	}
+}
+
+func TestOktaProvider_BackwardCompat_FutureField_FetchGroupsDisabled_NoFailure(t *testing.T) {
+	// Simulates a future scenario: provider_config has provider=okta and some
+	// new unrelated field, but fetch_groups=false. A user with exactly 100
+	// groups (default cap) must not trigger the API fallback and must not fail
+	// due to missing org_url/api_token.
+	p := &OktaProvider{}
+	jc := &jwtConfig{
+		OIDCDiscoveryURL: "https://example.okta.com",
+		ProviderConfig: map[string]interface{}{
+			"provider":       "okta",
+			"fetch_groups":   false,
+			"future_field_x": "some-value", // hypothetical future field
+			// no api_token, no org_url
+		},
+	}
+	if err := p.Initialize(context.Background(), jc); err != nil {
+		t.Fatalf("initialize should succeed with fetch_groups=false even without api_token: %v", err)
+	}
+
+	b := newOktaTestBackend(t)
+	role := newOktaRole("groups", "sub")
+
+	// user has exactly 100 groups — the default cap
+	groups100 := make([]interface{}, 100)
+	for i := range groups100 {
+		groups100[i] = fmt.Sprintf("group-%d", i)
+	}
+	claims := map[string]interface{}{
+		"sub":    "user@example.com",
+		"groups": groups100,
+	}
+
+	// Must NOT fail — fetch_groups=false means use token as-is
+	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
+	if err != nil {
+		t.Fatalf("unexpected error with fetch_groups=false and 100 groups: %v", err)
+	}
+	resultGroups, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{}, got %T", result)
+	}
+	if len(resultGroups) != 100 {
+		t.Errorf("expected 100 groups from token, got %d", len(resultGroups))
+	}
+}

--- a/provider_okta_test.go
+++ b/provider_okta_test.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// ---- test server ------------------------------------------------------------
+// test server
 
 // oktaServer is a TLS test server that simultaneously serves OIDC discovery
 // (so Vault can write a valid config) and the Okta admin groups API
@@ -91,7 +91,7 @@ func oktaGroupJSON(names ...string) string {
 	return string(b)
 }
 
-// ---- backend helpers --------------------------------------------------------
+// backend helpers
 
 // newOktaBackend configures a full Vault jwtAuthBackend via HandleRequest,
 // pointing both OIDC discovery and the Okta admin API at ts.
@@ -151,10 +151,10 @@ func newOktaBackend(t *testing.T, ts *oktaServer, providerExtra map[string]inter
 
 // injectTLSClient replaces the backend's providerCtx with one that carries the
 // test server's HTTP client. In FetchGroups, b.providerCtx is passed to
-// b.createCAContext which returns it as-is when OIDCDiscoveryCAPEM is empty;
-// that context then becomes o.ctx used by getOktaGroups for HTTP calls.
-// cachedConfig.OIDCDiscoveryCAPEM is cleared to prevent createCAContext from
-// building a CA-pinned transport that would shadow the injected client.
+// b.createCAContext which extracts the HTTP client value; that client is then
+// passed directly into getOktaGroups. cachedConfig.OIDCDiscoveryCAPEM is
+// cleared to prevent createCAContext from building a conflicting CA-pinned
+// transport that would shadow the injected client.
 func injectTLSClient(b logical.Backend, ts *oktaServer) {
 	backend := b.(*jwtAuthBackend)
 	if backend.cachedConfig != nil {
@@ -320,14 +320,14 @@ func TestOktaProvider_Initialize(t *testing.T) {
 	}
 }
 
-// ---- SensitiveKeys ----------------------------------------------------------
+// SensitiveKeys
 
 func TestOktaProvider_SensitiveKeys(t *testing.T) {
 	p := &OktaProvider{}
 	assert.Equal(t, []string{"api_token"}, p.SensitiveKeys())
 }
 
-// ---- FetchGroups — fetch_groups=false (token-only path) --------------------
+// FetchGroups — fetch_groups=false (token-only path)
 
 func TestOktaProvider_FetchGroups_FetchGroupsDisabled(t *testing.T) {
 	ts := newOktaServer(t)
@@ -390,7 +390,7 @@ func TestOktaProvider_FetchGroups_FetchGroupsDisabled(t *testing.T) {
 	})
 }
 
-// ---- FetchGroups — fast path (below cap, no API call) -----------------------
+// FetchGroups — fast path (below cap, no API call)
 
 func TestOktaProvider_FetchGroups_FastPath(t *testing.T) {
 	ts := newOktaServer(t)
@@ -458,7 +458,7 @@ func TestOktaProvider_FetchGroups_FastPath(t *testing.T) {
 	})
 }
 
-// ---- FetchGroups — API fallback (at or above cap) ---------------------------
+// FetchGroups — API fallback (at or above cap)
 
 func TestOktaProvider_FetchGroups_APIFallback(t *testing.T) {
 	t.Run("groups equal to cap triggers API call", func(t *testing.T) {
@@ -582,7 +582,7 @@ func TestOktaProvider_FetchGroups_APIFallback(t *testing.T) {
 
 }
 
-// ---- resolveUserID unit tests -----------------------------------------------
+// resolveUserID unit tests
 
 func TestOktaProvider_ResolveUserID(t *testing.T) {
 	tests := []struct {
@@ -662,7 +662,7 @@ func TestOktaProvider_ResolveUserID(t *testing.T) {
 	}
 }
 
-// ---- getOktaGroups unit tests -----------------------------------------------
+// getOktaGroups unit tests
 
 func TestOktaProvider_GetOktaGroups(t *testing.T) {
 	t.Run("single page returns all groups", func(t *testing.T) {
@@ -673,10 +673,9 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 		defer ts.Close()
 
 		p := &OktaProvider{
-			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-		groups, err := p.getOktaGroups("user@example.com")
+		groups, err := p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 		require.NoError(t, err)
 		assert.Len(t, groups, 3)
@@ -701,10 +700,9 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 		defer ts.Close()
 
 		p := &OktaProvider{
-			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-		groups, err := p.getOktaGroups("user@example.com")
+		groups, err := p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 		require.NoError(t, err)
 		assert.Len(t, groups, 5)
@@ -723,10 +721,9 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 		defer ts.Close()
 
 		p := &OktaProvider{
-			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-		groups, err := p.getOktaGroups("user@example.com")
+		groups, err := p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 		require.NoError(t, err)
 		assert.Len(t, groups, 2, "group with empty name must be dropped")
@@ -742,10 +739,9 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 		defer ts.Close()
 
 		p := &OktaProvider{
-			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "my-ssws-token", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-		_, _ = p.getOktaGroups("user@example.com")
+		_, _ = p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 		assert.Equal(t, "SSWS my-ssws-token", gotAuth)
 	})
@@ -769,10 +765,9 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 			defer ts.Close()
 
 			p := &OktaProvider{
-				ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 				config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 			}
-			_, err := p.getOktaGroups("user@example.com")
+			_, err := p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
@@ -787,16 +782,15 @@ func TestOktaProvider_GetOktaGroups(t *testing.T) {
 		defer ts.Close()
 
 		p := &OktaProvider{
-			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
 			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-		_, err := p.getOktaGroups("user@example.com")
+		_, err := p.getOktaGroups(context.Background(), ts.Client(), "user@example.com")
 
 		require.Error(t, err)
 	})
 }
 
-// ---- nextLink helper tests --------------------------------------------------
+// nextLink helper tests
 
 func TestNextLink(t *testing.T) {
 	tests := []struct {
@@ -841,7 +835,7 @@ func TestNextLink(t *testing.T) {
 	}
 }
 
-// ---- applyGroupsFilter unit tests -------------------------------------------
+// applyGroupsFilter unit tests
 
 func TestOktaProvider_ApplyGroupsFilter(t *testing.T) {
 	tests := []struct {
@@ -897,7 +891,7 @@ func TestOktaProvider_ApplyGroupsFilter(t *testing.T) {
 	}
 }
 
-// ---- backward compatibility tests -------------------------------------------
+// backward compatibility tests
 
 func TestOktaProvider_BackwardCompat(t *testing.T) {
 	t.Run("okta is registered in ProviderMap", func(t *testing.T) {

--- a/provider_okta_test.go
+++ b/provider_okta_test.go
@@ -1,1159 +1,953 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
 package jwtauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
-// ---- helpers ----------------------------------------------------------------
+// ---- test server ------------------------------------------------------------
 
-// newOktaTestBackend returns a minimal jwtAuthBackend suitable for unit tests.
-// It does not connect to Vault storage or a real OIDC server.
-func newOktaTestBackend(t *testing.T) *jwtAuthBackend {
+// oktaServer is a TLS test server that simultaneously serves OIDC discovery
+// (so Vault can write a valid config) and the Okta admin groups API
+// (so FetchGroups calls are intercepted without reaching the internet).
+type oktaServer struct {
+	t      *testing.T
+	server *httptest.Server
+
+	// groups is the list of group names returned by the admin API.
+	groups []string
+	// apiCallCount is incremented on every /api/v1/users/*/groups hit.
+	apiCallCount int
+}
+
+func newOktaServer(t *testing.T) *oktaServer {
 	t.Helper()
-	b := &jwtAuthBackend{
-		Backend:     &framework.Backend{},
-		providerCtx: context.Background(),
-		cachedConfig: &jwtConfig{
-			OIDCDiscoveryCAPEM: "",
-		},
-	}
-	return b
+	s := &oktaServer{t: t}
+	s.server = httptest.NewTLSServer(s)
+	t.Cleanup(s.server.Close)
+	return s
 }
 
-// newOktaRole returns a minimal jwtRole for use in FetchGroups tests.
-func newOktaRole(groupsClaim, userClaim string) *jwtRole {
-	return &jwtRole{
-		GroupsClaim: groupsClaim,
-		UserClaim:   userClaim,
+func (s *oktaServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.URL.Path == "/.well-known/openid-configuration":
+		w.Write([]byte(strings.Replace(`{
+			"issuer":                  "%s",
+			"authorization_endpoint": "%s/auth",
+			"token_endpoint":         "%s/token",
+			"jwks_uri":               "%s/certs",
+			"userinfo_endpoint":      "%s/userinfo"
+		}`, "%s", s.server.URL, -1)))
+	case strings.Contains(r.URL.Path, "/api/v1/users/"):
+		s.apiCallCount++
+		json.NewEncoder(w).Encode(makeOktaGroups(s.groups...)) //nolint:errcheck
+	default:
+		s.t.Errorf("unexpected request path: %q", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
 	}
 }
 
-// oktaGroupJSON returns a JSON array of Okta group objects for use in mock
-// server responses.
-func oktaGroupJSON(names ...string) string {
-	type profile struct {
-		Name string `json:"name"`
+// getTLSCert returns the server's self-signed certificate in PEM format,
+// suitable for use as oidc_discovery_ca_pem.
+func (s *oktaServer) getTLSCert() (string, error) {
+	cert := s.server.Certificate()
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, block); err != nil {
+		return "", err
 	}
-	type group struct {
-		ID      string  `json:"id"`
-		Profile profile `json:"profile"`
-	}
-	groups := make([]group, len(names))
+	return buf.String(), nil
+}
+
+// makeOktaGroups builds a slice of oktaGroup values for JSON encoding.
+func makeOktaGroups(names ...string) []oktaGroup {
+	out := make([]oktaGroup, len(names))
 	for i, n := range names {
-		groups[i] = group{ID: fmt.Sprintf("id-%d", i), Profile: profile{Name: n}}
+		out[i] = oktaGroup{ID: fmt.Sprintf("id-%d", i), Profile: oktaGroupProfile{Name: n}}
 	}
-	b, _ := json.Marshal(groups)
+	return out
+}
+
+// oktaGroupJSON returns a JSON-encoded Okta groups array used by
+// getOktaGroups unit tests that construct their own httptest servers.
+func oktaGroupJSON(names ...string) string {
+	b, _ := json.Marshal(makeOktaGroups(names...))
 	return string(b)
 }
 
-// buildJWTConfig builds a jwtConfig map suitable for passing to Initialize.
-func buildJWTConfig(orgURL string, extra map[string]interface{}) *jwtConfig {
+// ---- backend helpers --------------------------------------------------------
+
+// newOktaBackend configures a full Vault jwtAuthBackend via HandleRequest,
+// pointing both OIDC discovery and the Okta admin API at ts.
+// providerExtra merges into the provider_config map on top of the defaults
+// (provider=okta, org_url=ts.URL, api_token=test-token).
+// A role named "test" with user_claim=sub and groups_claim=groups is created.
+func newOktaBackend(t *testing.T, ts *oktaServer, providerExtra map[string]interface{}) (logical.Backend, logical.Storage) {
+	t.Helper()
+	cert, err := ts.getTLSCert()
+	require.NoError(t, err)
+
 	pc := map[string]interface{}{
 		"provider":  "okta",
+		"org_url":   ts.server.URL,
 		"api_token": "test-token",
 	}
-	if orgURL != "" {
-		pc["org_url"] = orgURL
-	}
-	for k, v := range extra {
+	for k, v := range providerExtra {
 		pc[k] = v
 	}
-	return &jwtConfig{
-		OIDCDiscoveryURL: "https://example.okta.com",
-		ProviderConfig:   pc,
+
+	b, storage := getBackend(t)
+	ctx := context.Background()
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"oidc_discovery_url":    ts.server.URL,
+			"oidc_discovery_ca_pem": cert,
+			"oidc_client_id":        "abc",
+			"oidc_client_secret":    "def",
+			"bound_issuer":          ts.server.URL,
+			"provider_config":       pc,
+		},
 	}
+	resp, err := b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.Falsef(t, resp != nil && resp.IsError(), "unexpected config error: %v", resp)
+
+	req = &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/test",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"user_claim":            "sub",
+			"groups_claim":          "groups",
+			"allowed_redirect_uris": []string{"https://example.com"},
+		},
+	}
+	resp, err = b.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.Falsef(t, resp != nil && resp.IsError(), "unexpected role error: %v", resp)
+
+	return b, storage
+}
+
+// injectTLSClient replaces the backend's providerCtx with one that carries the
+// test server's HTTP client. In FetchGroups, b.providerCtx is passed to
+// b.createCAContext which returns it as-is when OIDCDiscoveryCAPEM is empty;
+// that context then becomes o.ctx used by getOktaGroups for HTTP calls.
+// cachedConfig.OIDCDiscoveryCAPEM is cleared to prevent createCAContext from
+// building a CA-pinned transport that would shadow the injected client.
+func injectTLSClient(b logical.Backend, ts *oktaServer) {
+	backend := b.(*jwtAuthBackend)
+	if backend.cachedConfig != nil {
+		backend.cachedConfig.OIDCDiscoveryCAPEM = ""
+	}
+	backend.providerCtx = context.WithValue(
+		context.Background(), oauth2.HTTPClient, ts.server.Client(),
+	)
 }
 
 // ---- Initialize tests -------------------------------------------------------
 
-func TestOktaProvider_Initialize_Valid(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", nil)
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestOktaProvider_Initialize(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerCfg  map[string]interface{}
+		discoveryURL string
+		wantErr      bool
+		errContains  string
+		check        func(t *testing.T, p *OktaProvider)
+	}{
+		{
+			name: "valid config sets fields and defaults",
+			providerCfg: map[string]interface{}{
+				"org_url":   "https://example.okta.com",
+				"api_token": "test-token",
+			},
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.Equal(t, "https://example.okta.com", p.config.OrgURL)
+				assert.Equal(t, defaultOktaGroupsCap, p.config.GroupsCap)
+				assert.False(t, p.config.FetchGroups, "fetch_groups absent should default to false")
+			},
+		},
+		{
+			name:         "org_url derived from discovery URL when absent",
+			providerCfg:  map[string]interface{}{},
+			discoveryURL: "https://example.okta.com",
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.Equal(t, "https://example.okta.com", p.config.OrgURL)
+			},
+		},
+		{
+			name:         "org_url derived strips path from custom auth server URL",
+			providerCfg:  map[string]interface{}{},
+			discoveryURL: "https://example.okta.com/oauth2/aus1abc123",
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.Equal(t, "https://example.okta.com", p.config.OrgURL)
+			},
+		},
+		{
+			name: "fetch_groups absent defaults to false",
+			providerCfg: map[string]interface{}{
+				"org_url":   "https://example.okta.com",
+				"api_token": "test-token",
+			},
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.False(t, p.config.FetchGroups)
+			},
+		},
+		{
+			name: "fetch_groups=true stored correctly",
+			providerCfg: map[string]interface{}{
+				"org_url":      "https://example.okta.com",
+				"api_token":    "test-token",
+				"fetch_groups": true,
+			},
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.True(t, p.config.FetchGroups)
+			},
+		},
+		{
+			name: "fetch_groups=false does not require api_token",
+			providerCfg: map[string]interface{}{
+				"org_url":      "https://example.okta.com",
+				"fetch_groups": false,
+			},
+		},
+		{
+			name: "missing api_token with fetch_groups=true is an error",
+			providerCfg: map[string]interface{}{
+				"org_url":      "https://example.okta.com",
+				"fetch_groups": true,
+			},
+			wantErr:     true,
+			errContains: "api_token",
+		},
+		{
+			name: "non-https org_url is an error",
+			providerCfg: map[string]interface{}{
+				"org_url":   "http://example.okta.com",
+				"api_token": "test-token",
+			},
+			wantErr:     true,
+			errContains: "https",
+		},
+		{
+			name: "negative groups_cap is an error",
+			providerCfg: map[string]interface{}{
+				"org_url":    "https://example.okta.com",
+				"api_token":  "test-token",
+				"groups_cap": -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "groups_cap=0 defaults to 100",
+			providerCfg: map[string]interface{}{
+				"org_url":    "https://example.okta.com",
+				"api_token":  "test-token",
+				"groups_cap": 0,
+			},
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.Equal(t, defaultOktaGroupsCap, p.config.GroupsCap)
+			},
+		},
+		{
+			name: "invalid groups_filter regex is an error",
+			providerCfg: map[string]interface{}{
+				"org_url":       "https://example.okta.com",
+				"api_token":     "test-token",
+				"groups_filter": "[invalid",
+			},
+			wantErr:     true,
+			errContains: "groups_filter",
+		},
+		{
+			name: "valid groups_filter compiles regex",
+			providerCfg: map[string]interface{}{
+				"org_url":       "https://example.okta.com",
+				"api_token":     "test-token",
+				"groups_filter": "^vault-",
+			},
+			check: func(t *testing.T, p *OktaProvider) {
+				assert.NotNil(t, p.groupsFilter)
+			},
+		},
 	}
-	if p.config.OrgURL != "https://example.okta.com" {
-		t.Errorf("expected org_url to be set, got %q", p.config.OrgURL)
-	}
-	if p.config.GroupsCap != defaultOktaGroupsCap {
-		t.Errorf("expected default GroupsCap %d, got %d", defaultOktaGroupsCap, p.config.GroupsCap)
-	}
-	// fetch_groups not in map → should default to false
-	if p.config.FetchGroups {
-		t.Error("expected FetchGroups to default to false when key absent")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OktaProvider{}
+			discoveryURL := tt.discoveryURL
+			if discoveryURL == "" {
+				discoveryURL = "https://example.okta.com"
+			}
+			jc := &jwtConfig{
+				OIDCDiscoveryURL: discoveryURL,
+				ProviderConfig:   tt.providerCfg,
+			}
+			err := p.Initialize(context.Background(), jc)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, p)
+			}
+		})
 	}
 }
 
-func TestOktaProvider_Initialize_MissingOrgURL_DerivedFromDiscoveryURL(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("", nil) // no org_url — should be derived
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.config.OrgURL != "https://example.okta.com" {
-		t.Errorf("expected org_url derived as https://example.okta.com, got %q", p.config.OrgURL)
-	}
-}
-
-func TestOktaProvider_Initialize_OrgURLDerivedStripsPath(t *testing.T) {
-	// Custom auth server: discovery URL has /oauth2/... path that must be stripped
-	p := &OktaProvider{}
-	jc := buildJWTConfig("", nil)
-	jc.OIDCDiscoveryURL = "https://example.okta.com/oauth2/aus1abc123"
-	delete(jc.ProviderConfig, "org_url")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.config.OrgURL != "https://example.okta.com" {
-		t.Errorf("expected path stripped, got %q", p.config.OrgURL)
-	}
-}
-
-func TestOktaProvider_Initialize_MissingAPIToken_FetchGroupsTrue(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups": true,
-	})
-	delete(jc.ProviderConfig, "api_token")
-	err := p.Initialize(context.Background(), jc)
-	if err == nil {
-		t.Fatal("expected error for missing api_token with fetch_groups=true")
-	}
-	if !strings.Contains(err.Error(), "api_token") {
-		t.Errorf("expected error to mention api_token, got: %v", err)
-	}
-}
-
-func TestOktaProvider_Initialize_MissingAPIToken_FetchGroupsFalse(t *testing.T) {
-	// When fetch_groups=false, api_token is not required
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups": false,
-	})
-	delete(jc.ProviderConfig, "api_token")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error when fetch_groups=false and api_token missing: %v", err)
-	}
-}
-
-func TestOktaProvider_Initialize_NonHTTPSOrgURL(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("http://example.okta.com", nil) // http not https
-	err := p.Initialize(context.Background(), jc)
-	if err == nil {
-		t.Fatal("expected error for non-https org_url")
-	}
-	if !strings.Contains(err.Error(), "https") {
-		t.Errorf("expected error to mention https, got: %v", err)
-	}
-}
-
-func TestOktaProvider_Initialize_InvalidGroupsCap(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_cap": -1,
-	})
-	err := p.Initialize(context.Background(), jc)
-	if err == nil {
-		t.Fatal("expected error for negative groups_cap")
-	}
-}
-
-func TestOktaProvider_Initialize_GroupsCapZeroDefaultsTo100(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_cap": 0,
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.config.GroupsCap != defaultOktaGroupsCap {
-		t.Errorf("expected GroupsCap=%d when 0 supplied, got %d", defaultOktaGroupsCap, p.config.GroupsCap)
-	}
-}
-
-func TestOktaProvider_Initialize_InvalidGroupsFilter(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": "[invalid",
-	})
-	err := p.Initialize(context.Background(), jc)
-	if err == nil {
-		t.Fatal("expected error for invalid groups_filter regex")
-	}
-	if !strings.Contains(err.Error(), "groups_filter") {
-		t.Errorf("expected error to mention groups_filter, got: %v", err)
-	}
-}
-
-func TestOktaProvider_Initialize_ValidGroupsFilter(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": "^vault-",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.groupsFilter == nil {
-		t.Error("expected groupsFilter to be compiled")
-	}
-}
-
-func TestOktaProvider_Initialize_FetchGroupsExplicitFalse(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups": false,
-	})
-	delete(jc.ProviderConfig, "api_token")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.config.FetchGroups {
-		t.Error("expected FetchGroups=false when explicitly set to false")
-	}
-}
-
-// ---- SensitiveKeys tests ----------------------------------------------------
+// ---- SensitiveKeys ----------------------------------------------------------
 
 func TestOktaProvider_SensitiveKeys(t *testing.T) {
 	p := &OktaProvider{}
-	keys := p.SensitiveKeys()
-	if len(keys) != 1 || keys[0] != "api_token" {
-		t.Errorf("expected SensitiveKeys=[api_token], got %v", keys)
-	}
+	assert.Equal(t, []string{"api_token"}, p.SensitiveKeys())
 }
 
-// ---- FetchGroups — fetch_groups=false path ----------------------------------
+// ---- FetchGroups — fetch_groups=false (token-only path) --------------------
 
-func TestOktaProvider_FetchGroups_FetchGroupsDisabled_UsesToken(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups": false,
-	})
-	delete(jc.ProviderConfig, "api_token")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
+func TestOktaProvider_FetchGroups_FetchGroupsDisabled(t *testing.T) {
+	ts := newOktaServer(t)
+	ts.groups = []string{"api-group"} // must NOT appear in any result
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"g1", "g2", "g3"},
-	}
+	t.Run("uses token groups directly without calling API", func(t *testing.T) {
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{"fetch_groups": false})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
 
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups, ok := result.([]interface{})
-	if !ok {
-		t.Fatalf("expected []interface{}, got %T", result)
-	}
-	if len(groups) != 3 {
-		t.Errorf("expected 3 groups, got %d", len(groups))
-	}
-}
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
 
-func TestOktaProvider_FetchGroups_FetchGroupsDisabled_MissingClaim_Error(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups": false,
-	})
-	delete(jc.ProviderConfig, "api_token")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub": "user@example.com",
-		// no groups claim
-	}
-
-	_, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err == nil {
-		t.Fatal("expected error when groups claim missing and fetch_groups=false")
-	}
-}
-
-func TestOktaProvider_FetchGroups_FetchGroupsDisabled_FilterApplied(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"fetch_groups":  false,
-		"groups_filter": "^vault-",
-	})
-	delete(jc.ProviderConfig, "api_token")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"vault-admin", "corp-everyone", "vault-readonly"},
-	}
-
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups := result.([]interface{})
-	if len(groups) != 2 {
-		t.Errorf("expected 2 filtered groups, got %d: %v", len(groups), groups)
-	}
-	for _, g := range groups {
-		if !strings.HasPrefix(g.(string), "vault-") {
-			t.Errorf("expected only vault- groups, got %q", g)
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"token-g1", "token-g2"},
 		}
-	}
+
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		ts.apiCallCount = 0
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"token-g1", "token-g2"}, result)
+		assert.Equal(t, 0, ts.apiCallCount, "Okta API must not be called when fetch_groups=false")
+	})
+
+	t.Run("groups_filter applied to token groups", func(t *testing.T) {
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups":  false,
+			"groups_filter": "^vault-",
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
+
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
+
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"vault-admin", "corp-everyone", "vault-readonly"},
+		}
+
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 2)
+		for _, g := range groups {
+			assert.True(t, strings.HasPrefix(g.(string), "vault-"))
+		}
+	})
 }
 
 // ---- FetchGroups — fast path (below cap, no API call) -----------------------
 
-func TestOktaProvider_FetchGroups_FastPath_BelowCap_NoAPICall(t *testing.T) {
-	// Mock server that should NOT be called
-	called := false
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer ts.Close()
+func TestOktaProvider_FetchGroups_FastPath(t *testing.T) {
+	ts := newOktaServer(t)
+	ts.groups = []string{"api-group"} // must NOT appear in any result
 
-	p := &OktaProvider{}
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"groups_cap":   5,
-		"fetch_groups": true,
+	t.Run("groups below cap uses token without API call", func(t *testing.T) {
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups": true,
+			"groups_cap":   5,
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
+
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
+
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"g1", "g2", "g3"}, // 3 < cap of 5
+		}
+
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		ts.apiCallCount = 0
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, ts.apiCallCount, "API must not be called below cap")
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 3)
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
 
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	role := newOktaRole("groups", "sub")
-	// 3 groups < cap of 5 → fast path
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"g1", "g2", "g3"},
-	}
+	t.Run("groups below cap with filter — no API call, filter applied", func(t *testing.T) {
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups":  true,
+			"groups_cap":    5,
+			"groups_filter": "^vault-",
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
 
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if called {
-		t.Error("API should not have been called on fast path")
-	}
-	_ = result
-}
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
 
-func TestOktaProvider_FetchGroups_FastPath_WithFilter_NoAPICall(t *testing.T) {
-	called := false
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer ts.Close()
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"vault-admin", "corp-all", "vault-readonly"},
+		}
 
-	p := &OktaProvider{}
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"groups_cap":    5,
-		"groups_filter": "^vault-",
-		"fetch_groups":  true,
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		ts.apiCallCount = 0
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, ts.apiCallCount, "API must not be called below cap")
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 2)
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"vault-admin", "corp-all", "vault-readonly"},
-	}
-
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if called {
-		t.Error("API should not have been called on fast path")
-	}
-	groups := result.([]interface{})
-	if len(groups) != 2 {
-		t.Errorf("expected 2 filtered groups, got %d", len(groups))
-	}
 }
 
 // ---- FetchGroups — API fallback (at or above cap) ---------------------------
 
-func TestOktaProvider_FetchGroups_AtCap_TriggersAPI(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "/api/v1/users/") {
-			w.WriteHeader(http.StatusNotFound)
-			return
+func TestOktaProvider_FetchGroups_APIFallback(t *testing.T) {
+	t.Run("groups equal to cap triggers API call", func(t *testing.T) {
+		ts := newOktaServer(t)
+		ts.groups = []string{"api-g1", "api-g2", "api-g3", "api-g4", "api-g5"}
+
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups": true,
+			"groups_cap":   3,
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
+
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
+
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"x", "y", "z"}, // exactly 3 == cap
 		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3", "g4", "g5"))
-	}))
-	defer ts.Close()
 
-	p := &OktaProvider{}
-	p.ctx = context.Background()
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"groups_cap":   3,
-		"fetch_groups": true,
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, ts.apiCallCount, "API must be called at cap")
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 5)
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
 
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
-	role := newOktaRole("groups", "sub")
-	// exactly 3 groups == cap → fallback
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"x", "y", "z"},
-	}
+	t.Run("groups above cap triggers API call", func(t *testing.T) {
+		ts := newOktaServer(t)
+		ts.groups = []string{"full-g1", "full-g2"}
 
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups := result.([]interface{})
-	if len(groups) != 5 {
-		t.Errorf("expected 5 groups from API, got %d", len(groups))
-	}
-}
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups": true,
+			"groups_cap":   2,
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
 
-func TestOktaProvider_FetchGroups_ClaimAbsent_TriggersAPI(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, oktaGroupJSON("vault-admin"))
-	}))
-	defer ts.Close()
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
 
-	p := &OktaProvider{}
-	p.ctx = context.Background()
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"fetch_groups": true,
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
-	role := newOktaRole("groups", "sub")
-	// no groups claim at all → fallback
-	claims := map[string]interface{}{
-		"sub": "user@example.com",
-	}
-
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups := result.([]interface{})
-	if len(groups) != 1 || groups[0] != "vault-admin" {
-		t.Errorf("unexpected groups from API: %v", groups)
-	}
-}
-
-func TestOktaProvider_FetchGroups_AboveCap_TriggersAPI(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, oktaGroupJSON("full-g1", "full-g2"))
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{}
-	p.ctx = context.Background()
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"groups_cap":   2,
-		"fetch_groups": true,
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
-	role := newOktaRole("groups", "sub")
-	// 3 groups > cap of 2 → fallback
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": []interface{}{"a", "b", "c"},
-	}
-
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups := result.([]interface{})
-	if len(groups) != 2 {
-		t.Errorf("expected 2 groups from API, got %d", len(groups))
-	}
-}
-
-func TestOktaProvider_FetchGroups_APIFallback_WithFilter(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, oktaGroupJSON("vault-admin", "corp-all", "vault-readonly", "ad-sync-group"))
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{}
-	p.ctx = context.Background()
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"groups_filter": "^vault-",
-		"fetch_groups":  true,
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
-	role := newOktaRole("groups", "sub")
-	// no groups claim → API fallback
-	claims := map[string]interface{}{
-		"sub": "user@example.com",
-	}
-
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	groups := result.([]interface{})
-	if len(groups) != 2 {
-		t.Errorf("expected 2 filtered groups, got %d: %v", len(groups), groups)
-	}
-	for _, g := range groups {
-		if !strings.HasPrefix(g.(string), "vault-") {
-			t.Errorf("expected only vault- groups, got %q", g)
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{
+			"sub":    "user@example.com",
+			"groups": []interface{}{"a", "b", "c"}, // 3 > cap of 2
 		}
-	}
-}
 
-func TestOktaProvider_FetchGroups_EmptyAPIResult_NoError(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "[]")
-	}))
-	defer ts.Close()
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
 
-	p := &OktaProvider{}
-	p.ctx = context.Background()
-	jc := buildJWTConfig(ts.URL, map[string]interface{}{
-		"fetch_groups": true,
+		require.NoError(t, err)
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 2)
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
 
-	b := newOktaTestBackend(t)
-	b.providerCtx = context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client())
-	b.cachedConfig = &jwtConfig{OIDCDiscoveryCAPEM: ""}
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub": "user@example.com",
-	}
+	t.Run("absent groups claim triggers API call", func(t *testing.T) {
+		ts := newOktaServer(t)
+		ts.groups = []string{"vault-admin"}
 
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error for empty group list: %v", err)
-	}
-	groups, ok := result.([]interface{})
-	if !ok {
-		// nil result is also acceptable for empty list
-		return
-	}
-	if len(groups) != 0 {
-		t.Errorf("expected empty groups list, got %v", groups)
-	}
-}
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{"fetch_groups": true})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
 
-// ---- resolveUserID tests ----------------------------------------------------
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
 
-func TestOktaProvider_ResolveUserID_FromUserIDClaim(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"user_id_claim": "email",
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{"sub": "user@example.com"} // no groups
+
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"vault-admin"}, groups)
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub":   "00u1abc",
-		"email": "user@example.com",
-	}
+	t.Run("groups_filter applied to API results", func(t *testing.T) {
+		ts := newOktaServer(t)
+		ts.groups = []string{"vault-admin", "corp-all", "vault-readonly", "ad-sync-group"}
 
-	id, err := p.resolveUserID(b, claims, role)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id != "user@example.com" {
-		t.Errorf("expected user@example.com, got %q", id)
-	}
-}
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{
+			"fetch_groups":  true,
+			"groups_filter": "^vault-",
+		})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
 
-func TestOktaProvider_ResolveUserID_FallsBackToRoleUserClaim(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", nil) // no user_id_claim
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub") // role.UserClaim = "sub"
-	claims := map[string]interface{}{
-		"sub": "00u1abc",
-	}
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		allClaims := map[string]interface{}{"sub": "user@example.com"} // no groups → API
 
-	id, err := p.resolveUserID(b, claims, role)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id != "00u1abc" {
-		t.Errorf("expected 00u1abc, got %q", id)
-	}
-}
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
 
-func TestOktaProvider_ResolveUserID_ClaimNotInToken_Error(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"user_id_claim": "email",
+		require.NoError(t, err)
+		groups, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, groups, 2)
+		for _, g := range groups {
+			assert.True(t, strings.HasPrefix(g.(string), "vault-"))
+		}
 	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub": "00u1abc",
-		// email claim absent
-	}
-
-	_, err := p.resolveUserID(b, claims, role)
-	if err == nil {
-		t.Fatal("expected error when user_id_claim not found in token")
-	}
-	if !strings.Contains(err.Error(), "email") {
-		t.Errorf("expected error to mention claim name, got: %v", err)
-	}
 }
 
-func TestOktaProvider_ResolveUserID_ClaimNotString_Error(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"user_id_claim": "sub",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
+// ---- resolveUserID unit tests -----------------------------------------------
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
-	claims := map[string]interface{}{
-		"sub": 12345, // not a string
-	}
-
-	_, err := p.resolveUserID(b, claims, role)
-	if err == nil {
-		t.Fatal("expected error when claim value is not a string")
-	}
-}
-
-func TestOktaProvider_ResolveUserID_BothClaimsUnset_Error(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", nil) // no user_id_claim
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "") // role.UserClaim also empty
-	claims := map[string]interface{}{
-		"sub": "00u1abc",
-	}
-
-	_, err := p.resolveUserID(b, claims, role)
-	if err == nil {
-		t.Fatal("expected error when both user_id_claim and role.UserClaim are empty")
-	}
-}
-
-// ---- getOktaGroups pagination tests -----------------------------------------
-
-func TestOktaProvider_GetOktaGroups_SinglePage(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		// no Link header → single page
-		fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3"))
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
+func TestOktaProvider_ResolveUserID(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfgClaim    string // user_id_claim in provider config
+		roleClaim   string // role.UserClaim
+		claims      map[string]interface{}
+		wantID      string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "uses configured user_id_claim",
+			cfgClaim:  "email",
+			roleClaim: "sub",
+			claims:    map[string]interface{}{"sub": "00u1abc", "email": "user@example.com"},
+			wantID:    "user@example.com",
+		},
+		{
+			name:      "falls back to role user_claim when user_id_claim unset",
+			cfgClaim:  "",
+			roleClaim: "sub",
+			claims:    map[string]interface{}{"sub": "00u1abc"},
+			wantID:    "00u1abc",
+		},
+		{
+			name:        "claim absent from token returns error",
+			cfgClaim:    "email",
+			roleClaim:   "sub",
+			claims:      map[string]interface{}{"sub": "00u1abc"},
+			wantErr:     true,
+			errContains: "email",
+		},
+		{
+			name:      "claim value not a string returns error",
+			cfgClaim:  "sub",
+			roleClaim: "sub",
+			claims:    map[string]interface{}{"sub": 12345},
+			wantErr:   true,
+		},
+		{
+			name:      "both user_id_claim and role.UserClaim empty returns error",
+			cfgClaim:  "",
+			roleClaim: "",
+			claims:    map[string]interface{}{"sub": "00u1abc"},
+			wantErr:   true,
 		},
 	}
 
-	groups, err := p.getOktaGroups("user@example.com")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(groups) != 3 {
-		t.Errorf("expected 3 groups, got %d", len(groups))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OktaProvider{}
+			pc := map[string]interface{}{
+				"org_url":   "https://example.okta.com",
+				"api_token": "test-token",
+			}
+			if tt.cfgClaim != "" {
+				pc["user_id_claim"] = tt.cfgClaim
+			}
+			jc := &jwtConfig{OIDCDiscoveryURL: "https://example.okta.com", ProviderConfig: pc}
+			require.NoError(t, p.Initialize(context.Background(), jc))
+
+			b, _ := getBackend(t)
+			role := &jwtRole{GroupsClaim: "groups", UserClaim: tt.roleClaim}
+
+			id, err := p.resolveUserID(b.(*jwtAuthBackend), tt.claims, role)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, id)
+		})
 	}
 }
 
-func TestOktaProvider_GetOktaGroups_MultiPage_PaginationFollowed(t *testing.T) {
-	page := 0
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		page++
-		switch page {
-		case 1:
-			// First page — include Link: rel="next"
-			w.Header().Set("Link", fmt.Sprintf(`<https://%s/api/v1/users/user%%40example.com/groups?after=cursor1&limit=200>; rel="next"`, r.Host))
+// ---- getOktaGroups unit tests -----------------------------------------------
+
+func TestOktaProvider_GetOktaGroups(t *testing.T) {
+	t.Run("single page returns all groups", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3"))
-		case 2:
-			// Second page — no next link
-			fmt.Fprint(w, oktaGroupJSON("g4", "g5"))
-		default:
-			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		p := &OktaProvider{
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
 		}
-	}))
-	defer ts.Close()
+		groups, err := p.getOktaGroups("user@example.com")
 
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
+		require.NoError(t, err)
+		assert.Len(t, groups, 3)
+	})
+
+	t.Run("pagination follows Link rel=next across pages", func(t *testing.T) {
+		page := 0
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			page++
+			switch page {
+			case 1:
+				w.Header().Set("Link", fmt.Sprintf(
+					`<https://%s/api/v1/users/user%%40example.com/groups?after=cur&limit=200>; rel="next"`, r.Host))
+				fmt.Fprint(w, oktaGroupJSON("g1", "g2", "g3"))
+			case 2:
+				fmt.Fprint(w, oktaGroupJSON("g4", "g5"))
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+		defer ts.Close()
+
+		p := &OktaProvider{
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
+		}
+		groups, err := p.getOktaGroups("user@example.com")
+
+		require.NoError(t, err)
+		assert.Len(t, groups, 5)
+		assert.Equal(t, 2, page, "expected exactly 2 API pages")
+	})
+
+	t.Run("empty profile name is silently dropped", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[
+				{"id":"id1","profile":{"name":"vault-admin"}},
+				{"id":"id2","profile":{"name":""}},
+				{"id":"id3","profile":{"name":"vault-readonly"}}
+			]`)
+		}))
+		defer ts.Close()
+
+		p := &OktaProvider{
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
+		}
+		groups, err := p.getOktaGroups("user@example.com")
+
+		require.NoError(t, err)
+		assert.Len(t, groups, 2, "group with empty name must be dropped")
+	})
+
+	t.Run("SSWS token sent in Authorization header", func(t *testing.T) {
+		var gotAuth string
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "[]")
+		}))
+		defer ts.Close()
+
+		p := &OktaProvider{
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "my-ssws-token", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
+		}
+		_, _ = p.getOktaGroups("user@example.com")
+
+		assert.Equal(t, "SSWS my-ssws-token", gotAuth)
+	})
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		errMsg string
+	}{
+		{"HTTP 401 returns error mentioning status", http.StatusUnauthorized, `{"errorCode":"E0000011"}`, "401"},
+		{"HTTP 403 returns error mentioning status", http.StatusForbidden, `{"errorCode":"E0000006"}`, "403"},
+		{"HTTP 500 returns error", http.StatusInternalServerError, "", "500"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer ts.Close()
+
+			p := &OktaProvider{
+				ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+				config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
+			}
+			_, err := p.getOktaGroups("user@example.com")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
 	}
 
-	groups, err := p.getOktaGroups("user@example.com")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(groups) != 5 {
-		t.Errorf("expected 5 groups across 2 pages, got %d: %v", len(groups), groups)
-	}
-	if page != 2 {
-		t.Errorf("expected exactly 2 API calls, made %d", page)
-	}
-}
+	t.Run("invalid JSON response returns error", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `not-valid-json`)
+		}))
+		defer ts.Close()
 
-func TestOktaProvider_GetOktaGroups_API401_Error(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, `{"errorCode":"E0000011","errorSummary":"Invalid token"}`)
-	}))
-	defer ts.Close()
+		p := &OktaProvider{
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
+			config: OktaProviderConfig{OrgURL: ts.URL, APIToken: "tok", FetchGroups: true, GroupsCap: defaultOktaGroupsCap},
+		}
+		_, err := p.getOktaGroups("user@example.com")
 
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "bad-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	_, err := p.getOktaGroups("user@example.com")
-	if err == nil {
-		t.Fatal("expected error for 401 response")
-	}
-	if !strings.Contains(err.Error(), "401") {
-		t.Errorf("expected error to mention 401, got: %v", err)
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_API403_Error(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprint(w, `{"errorCode":"E0000006","errorSummary":"You do not have permission"}`)
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "limited-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	_, err := p.getOktaGroups("user@example.com")
-	if err == nil {
-		t.Fatal("expected error for 403 response")
-	}
-	if !strings.Contains(err.Error(), "403") {
-		t.Errorf("expected error to mention 403, got: %v", err)
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_API500_Error(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	_, err := p.getOktaGroups("user@example.com")
-	if err == nil {
-		t.Fatal("expected error for 500 response")
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_InvalidJSON_Error(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `not-valid-json`)
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	_, err := p.getOktaGroups("user@example.com")
-	if err == nil {
-		t.Fatal("expected error for invalid JSON response")
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_EmptyProfileName_Dropped(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		// one group has empty name — should be silently dropped
-		fmt.Fprint(w, `[
-			{"id":"id1","profile":{"name":"vault-admin"}},
-			{"id":"id2","profile":{"name":""}},
-			{"id":"id3","profile":{"name":"vault-readonly"}}
-		]`)
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	groups, err := p.getOktaGroups("user@example.com")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(groups) != 2 {
-		t.Errorf("expected 2 groups (empty name dropped), got %d: %v", len(groups), groups)
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_SSWSAuthHeader(t *testing.T) {
-	var gotAuth string
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "[]")
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "my-ssws-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	_, _ = p.getOktaGroups("user@example.com")
-	expected := "SSWS my-ssws-token"
-	if gotAuth != expected {
-		t.Errorf("expected Authorization header %q, got %q", expected, gotAuth)
-	}
-}
-
-func TestOktaProvider_GetOktaGroups_UserIDPathEncoded(t *testing.T) {
-	var gotRequestURI string
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// RequestURI is the unmodified request-target as sent by the client,
-		// preserving any percent-encoding applied by url.PathEscape.
-		gotRequestURI = r.RequestURI
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "[]")
-	}))
-	defer ts.Close()
-
-	p := &OktaProvider{
-		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, ts.Client()),
-		config: OktaProviderConfig{
-			OrgURL:      ts.URL,
-			APIToken:    "test-token",
-			FetchGroups: true,
-			GroupsCap:   defaultOktaGroupsCap,
-		},
-	}
-
-	// Use a user ID containing a space — url.PathEscape encodes it as %20.
-	_, _ = p.getOktaGroups("john doe")
-	if !strings.Contains(gotRequestURI, "john%20doe") {
-		t.Errorf("expected space percent-encoded as %%20 in request URI, got %q", gotRequestURI)
-	}
+		require.Error(t, err)
+	})
 }
 
 // ---- nextLink helper tests --------------------------------------------------
 
-func TestNextLink_Present(t *testing.T) {
-	headers := []string{
-		`<https://example.okta.com/api/v1/users/me/groups?after=cursor>; rel="next"`,
-	}
-	got := nextLink(headers)
-	want := "https://example.okta.com/api/v1/users/me/groups?after=cursor"
-	if got != want {
-		t.Errorf("expected %q, got %q", want, got)
-	}
-}
-
-func TestNextLink_Absent(t *testing.T) {
-	headers := []string{
-		`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`,
-	}
-	got := nextLink(headers)
-	if got != "" {
-		t.Errorf("expected empty string, got %q", got)
-	}
-}
-
-func TestNextLink_MultipleHeaders_ReturnsNext(t *testing.T) {
-	headers := []string{
-		`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`,
-		`<https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200>; rel="next"`,
-	}
-	got := nextLink(headers)
-	want := "https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200"
-	if got != want {
-		t.Errorf("expected %q, got %q", want, got)
-	}
-}
-
-func TestNextLink_Empty(t *testing.T) {
-	got := nextLink([]string{})
-	if got != "" {
-		t.Errorf("expected empty string for empty headers, got %q", got)
-	}
-}
-
-func TestNextLink_MalformedHeader(t *testing.T) {
-	headers := []string{"not-a-link-header"}
-	got := nextLink(headers)
-	if got != "" {
-		t.Errorf("expected empty string for malformed header, got %q", got)
-	}
-}
-
-// ---- applyGroupsFilter tests ------------------------------------------------
-
-func TestApplyGroupsFilter_MatchesSubset(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": "^vault-",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	list := []interface{}{"vault-admin", "corp-all", "vault-readonly", "ad-sync"}
-	result := p.applyGroupsFilter(b, list)
-	if len(result) != 2 {
-		t.Errorf("expected 2 matching groups, got %d: %v", len(result), result)
-	}
-}
-
-func TestApplyGroupsFilter_MatchesAll(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": ".*",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	list := []interface{}{"g1", "g2", "g3"}
-	result := p.applyGroupsFilter(b, list)
-	if len(result) != 3 {
-		t.Errorf("expected all 3 groups, got %d", len(result))
-	}
-}
-
-func TestApplyGroupsFilter_MatchesNone(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": "^nomatch-",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	list := []interface{}{"g1", "g2", "g3"}
-	result := p.applyGroupsFilter(b, list)
-	if len(result) != 0 {
-		t.Errorf("expected 0 matching groups, got %d", len(result))
-	}
-}
-
-func TestApplyGroupsFilter_NonStringEntriesDropped(t *testing.T) {
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", map[string]interface{}{
-		"groups_filter": ".*",
-	})
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-
-	b := newOktaTestBackend(t)
-	list := []interface{}{"valid-group", 123, nil, "another-group"}
-	result := p.applyGroupsFilter(b, list)
-	if len(result) != 2 {
-		t.Errorf("expected 2 string groups (non-strings dropped), got %d: %v", len(result), result)
-	}
-}
-
-// ---- backward compatibility test --------------------------------------------
-
-func TestOktaProvider_BackwardCompat_NoProviderConfig_GeneralFlowUnaffected(t *testing.T) {
-	// Verifies that OktaProvider is entirely opt-in: when provider_config is
-	// absent, ProviderMap returns nil and the general JWT flow runs unchanged.
-	pm := ProviderMap()
-	if pm["okta"] == nil {
-		t.Fatal("okta must be registered in ProviderMap")
-	}
-	// Absence of provider_config means NewProviderConfig returns (nil, nil)
-	// — tested at the framework level; here we just confirm registration.
-	p, ok := pm["okta"].(*OktaProvider)
-	if !ok {
-		t.Fatalf("expected *OktaProvider in ProviderMap, got %T", pm["okta"])
-	}
-	_ = p
-}
-
-func TestOktaProvider_BackwardCompat_FetchGroupsDefaultFalse(t *testing.T) {
-	// When fetch_groups key is absent from provider_config, it defaults to false.
-	// Existing configs without fetch_groups therefore use only token groups.
-	// fetch_groups must be explicitly set to true to enable API fetching.
-	p := &OktaProvider{}
-	jc := buildJWTConfig("https://example.okta.com", nil)
-	// Confirm key is absent
-	delete(jc.ProviderConfig, "fetch_groups")
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize: %v", err)
-	}
-	if p.config.FetchGroups {
-		t.Error("expected FetchGroups=false when key absent")
-	}
-}
-
-func TestOktaProvider_BackwardCompat_FutureField_FetchGroupsDisabled_NoFailure(t *testing.T) {
-	// Simulates a future scenario: provider_config has provider=okta and some
-	// new unrelated field, but fetch_groups=false. A user with exactly 100
-	// groups (default cap) must not trigger the API fallback and must not fail
-	// due to missing org_url/api_token.
-	p := &OktaProvider{}
-	jc := &jwtConfig{
-		OIDCDiscoveryURL: "https://example.okta.com",
-		ProviderConfig: map[string]interface{}{
-			"provider":       "okta",
-			"fetch_groups":   false,
-			"future_field_x": "some-value", // hypothetical future field
-			// no api_token, no org_url
+func TestNextLink(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		want    string
+	}{
+		{
+			name:    "rel=next present",
+			headers: []string{`<https://example.okta.com/api/v1/users/me/groups?after=cursor>; rel="next"`},
+			want:    "https://example.okta.com/api/v1/users/me/groups?after=cursor",
+		},
+		{
+			name:    "rel=self only returns empty string",
+			headers: []string{`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`},
+			want:    "",
+		},
+		{
+			name: "multiple Link headers returns rel=next",
+			headers: []string{
+				`<https://example.okta.com/api/v1/users/me/groups?limit=200>; rel="self"`,
+				`<https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200>; rel="next"`,
+			},
+			want: "https://example.okta.com/api/v1/users/me/groups?after=cur&limit=200",
+		},
+		{
+			name:    "empty header slice returns empty string",
+			headers: []string{},
+			want:    "",
+		},
+		{
+			name:    "malformed header returns empty string",
+			headers: []string{"not-a-link-header"},
+			want:    "",
 		},
 	}
-	if err := p.Initialize(context.Background(), jc); err != nil {
-		t.Fatalf("initialize should succeed with fetch_groups=false even without api_token: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextLink(tt.headers))
+		})
+	}
+}
+
+// ---- applyGroupsFilter unit tests -------------------------------------------
+
+func TestOktaProvider_ApplyGroupsFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  string
+		input   []interface{}
+		wantLen int
+	}{
+		{
+			name:    "matches subset",
+			filter:  "^vault-",
+			input:   []interface{}{"vault-admin", "corp-all", "vault-readonly", "ad-sync"},
+			wantLen: 2,
+		},
+		{
+			name:    "matches all",
+			filter:  ".*",
+			input:   []interface{}{"g1", "g2", "g3"},
+			wantLen: 3,
+		},
+		{
+			name:    "matches none",
+			filter:  "^nomatch-",
+			input:   []interface{}{"g1", "g2", "g3"},
+			wantLen: 0,
+		},
+		{
+			name:    "non-string entries are silently dropped",
+			filter:  ".*",
+			input:   []interface{}{"valid-group", 123, nil, "another-group"},
+			wantLen: 2,
+		},
 	}
 
-	b := newOktaTestBackend(t)
-	role := newOktaRole("groups", "sub")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OktaProvider{}
+			jc := &jwtConfig{
+				OIDCDiscoveryURL: "https://example.okta.com",
+				ProviderConfig: map[string]interface{}{
+					"org_url":       "https://example.okta.com",
+					"api_token":     "test-token",
+					"groups_filter": tt.filter,
+				},
+			}
+			require.NoError(t, p.Initialize(context.Background(), jc))
 
-	// user has exactly 100 groups — the default cap
-	groups100 := make([]interface{}, 100)
-	for i := range groups100 {
-		groups100[i] = fmt.Sprintf("group-%d", i)
-	}
-	claims := map[string]interface{}{
-		"sub":    "user@example.com",
-		"groups": groups100,
-	}
+			b, _ := getBackend(t)
+			result := p.applyGroupsFilter(b.(*jwtAuthBackend), tt.input)
 
-	// Must NOT fail — fetch_groups=false means use token as-is
-	result, err := p.FetchGroups(context.Background(), b, claims, role, nil)
-	if err != nil {
-		t.Fatalf("unexpected error with fetch_groups=false and 100 groups: %v", err)
+			assert.Len(t, result, tt.wantLen)
+		})
 	}
-	resultGroups, ok := result.([]interface{})
-	if !ok {
-		t.Fatalf("expected []interface{}, got %T", result)
-	}
-	if len(resultGroups) != 100 {
-		t.Errorf("expected 100 groups from token, got %d", len(resultGroups))
-	}
+}
+
+// ---- backward compatibility tests -------------------------------------------
+
+func TestOktaProvider_BackwardCompat(t *testing.T) {
+	t.Run("okta is registered in ProviderMap", func(t *testing.T) {
+		pm := ProviderMap()
+		require.NotNil(t, pm["okta"])
+		_, ok := pm["okta"].(*OktaProvider)
+		assert.True(t, ok)
+	})
+
+	t.Run("fetch_groups absent defaults to false — only token groups used", func(t *testing.T) {
+		p := &OktaProvider{}
+		jc := &jwtConfig{
+			OIDCDiscoveryURL: "https://example.okta.com",
+			ProviderConfig: map[string]interface{}{
+				"org_url":   "https://example.okta.com",
+				"api_token": "test-token",
+				// fetch_groups intentionally absent
+			},
+		}
+		require.NoError(t, p.Initialize(context.Background(), jc))
+		assert.False(t, p.config.FetchGroups)
+	})
+
+	t.Run("fetch_groups=false with 100 token groups uses token as-is without API call", func(t *testing.T) {
+		ts := newOktaServer(t)
+		ts.groups = []string{"should-not-appear"}
+
+		b, storage := newOktaBackend(t, ts, map[string]interface{}{"fetch_groups": false})
+		injectTLSClient(b, ts)
+		ctx := context.Background()
+
+		config, err := b.(*jwtAuthBackend).config(ctx, storage)
+		require.NoError(t, err)
+		provider, err := NewProviderConfig(ctx, config, ProviderMap())
+		require.NoError(t, err)
+
+		role := &jwtRole{GroupsClaim: "groups", UserClaim: "sub"}
+		groups100 := make([]interface{}, 100)
+		for i := range groups100 {
+			groups100[i] = fmt.Sprintf("group-%d", i)
+		}
+		allClaims := map[string]interface{}{"sub": "user@example.com", "groups": groups100}
+
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token"})
+		result, err := b.(*jwtAuthBackend).fetchGroups(ctx, provider, allClaims, role, tokenSource)
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, ts.apiCallCount, "API must not be called when fetch_groups=false")
+		list, ok := normalizeList(result)
+		require.True(t, ok)
+		assert.Len(t, list, 100)
+	})
 }

--- a/provider_okta_test.go
+++ b/provider_okta_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jwtauth


### PR DESCRIPTION
Jira : https://hashicorp.atlassian.net/browse/VAULT-43952

## Overview
Adds Okta provider to JWT/OIDC auth plugin with group fetching that handles Okta's silent group truncation in ID tokens.

## Problem
Okta truncates groups in ID tokens when users exceed a threshold (default: 100), leading to incomplete group assignments in Vault.

## Solution
Implements two-phase group fetching:
- **Fast path**: Uses token groups when `groups < groups_cap` (no API call)
- **Slow path**: Fetches from Okta Admin API when truncation detected (`groups >= groups_cap`)

## Key Features
- **`fetch_groups` flag**: Enable/disable API fallback (default: `false` for backward compatibility)
- **Auto-derive `org_url`**: Automatically extracts from `oidc_discovery_url` if not provided
- **Truncation detection**: Automatically detects when groups are truncated at boundary based on `groups_cap`
- **Pagination support**: Handles users with large number of groups
- **Groups filtering**: Regex-based filtering with `groups_filter`
- **Flexible user ID**: Configurable via `user_id_claim`, falls back to role's `user_claim`

## Configuration Example
```hcl
provider_config = {
  provider       = "okta"
  org_url        = "https://example.okta.com"  # Optional if oidc_discovery_url set
  api_token      = "00abc...xyz"               # Required only when fetch_groups=true
  fetch_groups   = true                        # Enable API fallback
  groups_cap     = 100                         # Truncation threshold
  groups_filter  = "^vault-"                   # Optional regex filter
  user_id_claim  = "email"                     # Optional, defaults to role's user_claim
}
```

## Files Changed
- **New**: `provider_okta.go` (450 lines) - Provider implementation
- **New**: `provider_okta_test.go` (950 lines) - 39 comprehensive test cases
- **Modified**: `provider_config.go` - Register Okta provider

## Backward Compatibility
This addition is fully backward compatible - `fetch_groups` defaults to `false` (token-only mode)


# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
