### PR TITLE
auth/oidc: support Azure Workload Identity for OIDC client auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+IMPROVEMENTS:
+* auth/oidc: Support authenticating the OIDC client to Microsoft Entra ID with an
+  Azure Workload Identity federated token (`client_assertion`) instead of a static
+  `oidc_client_secret`. Enable by setting `use_workload_identity=true` in the Azure
+  `provider_config`; the pod must be configured for Azure Workload Identity so that
+  the `AZURE_FEDERATED_TOKEN_FILE` environment variable is set.
+
 ## v0.26.2
 ### May 7, 2026
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ The custom handlers will be standalone objects defined in their own file (one
 per provider). They'll be part of the main jwtauth package to avoid potential
 circular import issues.
 
+#### Azure provider_config options
+
+The `azure` provider supports the following `provider_config` keys:
+
+* `fetch_groups` (bool) - fetch group membership from the Microsoft Graph API.
+* `use_workload_identity` (bool) - authenticate the OIDC client to Microsoft
+  Entra ID using an Azure Workload Identity federated token (`client_assertion`)
+  instead of a static `oidc_client_secret`. When enabled, `oidc_client_id` is
+  required and `oidc_client_secret` must be empty. The Vault pod must be
+  configured for Azure Workload Identity (the `azure.workload.identity/use` pod
+  label and the service account `azure.workload.identity/client-id` annotation)
+  so that the `AZURE_FEDERATED_TOKEN_FILE` environment variable is projected into
+  the container. A federated credential must be configured on the Entra app
+  registration trusting the cluster's OIDC issuer and the Vault service account.
+
+  ```
+  vault write auth/oidc/config \
+      oidc_discovery_url="https://login.microsoftonline.com/$TENANT_ID/v2.0" \
+      oidc_client_id="$CLIENT_ID" \
+      provider_config='{"provider":"azure","use_workload_identity":true}'
+  ```
+
 ### Tests
 
 If you are developing this plugin and want to verify it is still

--- a/path_config.go
+++ b/path_config.go
@@ -275,18 +275,31 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		methodCount++
 	}
 
+	// Azure Workload Identity authenticates the OIDC client to Microsoft Entra
+	// ID with a federated token (client_assertion) rather than a client secret.
+	// In that mode oidc_client_id is required and oidc_client_secret must be empty.
+	azureWorkloadIdentity := config.azureWorkloadIdentityEnabled()
+	if azureWorkloadIdentity {
+		if config.OIDCClientID == "" {
+			return logical.ErrorResponse("'oidc_client_id' must be set when Azure workload identity is enabled"), nil
+		}
+		if config.OIDCClientSecret != "" {
+			return logical.ErrorResponse("'oidc_client_secret' must not be set when Azure workload identity is enabled"), nil
+		}
+	}
+
 	var jwksPairs []*JWKSPair
 	switch {
 	case methodCount != 1:
 		return logical.ErrorResponse("exactly one of 'jwt_validation_pubkeys', 'jwks_url', 'jwks_pairs' or 'oidc_discovery_url' must be set"), nil
 
-	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
+	case config.OIDCClientID != "" && config.OIDCClientSecret == "" && !azureWorkloadIdentity,
 		config.OIDCClientID == "" && config.OIDCClientSecret != "":
 		return logical.ErrorResponse("both 'oidc_client_id' and 'oidc_client_secret' must be set for OIDC"), nil
 
 	case config.OIDCDiscoveryURL != "":
 		var err error
-		if config.OIDCClientID != "" && config.OIDCClientSecret != "" {
+		if config.OIDCClientID != "" && (config.OIDCClientSecret != "" || azureWorkloadIdentity) {
 			_, err = b.createProvider(config)
 		} else {
 			_, err = jwt.NewOIDCDiscoveryKeySet(ctx, config.OIDCDiscoveryURL, config.OIDCDiscoveryCAPEM)
@@ -546,7 +559,7 @@ func (c jwtConfig) authType() int {
 	case len(c.JWKSPairs) > 0:
 		return MultiJWKS
 	case c.OIDCDiscoveryURL != "":
-		if c.OIDCClientID != "" && c.OIDCClientSecret != "" {
+		if c.OIDCClientID != "" && (c.OIDCClientSecret != "" || c.azureWorkloadIdentityEnabled()) {
 			return OIDCFlow
 		}
 		return OIDCDiscovery

--- a/path_oidc.go
+++ b/path_oidc.go
@@ -479,6 +479,14 @@ func (b *jwtAuthBackend) createOIDCRequest(config *jwtConfig, role *jwtRole, rol
 		oidc.WithScopes(role.OIDCScopes...),
 	}
 
+	// When Azure Workload Identity is enabled, authenticate the OIDC client to
+	// Microsoft Entra ID using a federated token (client_assertion) read from
+	// AZURE_FEDERATED_TOKEN_FILE instead of a static client secret. cap sends
+	// the assertion during the authorization code exchange (see Provider.Exchange).
+	if config.azureWorkloadIdentityEnabled() {
+		options = append(options, oidc.WithClientAssertionJWT(azureWorkloadIdentityAssertion{}))
+	}
+
 	if config.hasType(responseTypeIDToken) {
 		options = append(options, oidc.WithImplicitFlow())
 	} else if config.hasType(responseTypeCode) {

--- a/provider_azure.go
+++ b/provider_azure.go
@@ -11,12 +11,19 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/oauth2"
 )
+
+// azureFederatedTokenFileEnv is the environment variable that the Azure
+// Workload Identity mutating webhook injects into a pod. It points to the file
+// containing the projected Kubernetes service account token, which is used as
+// the OIDC client_assertion when authenticating to Microsoft Entra ID.
+const azureFederatedTokenFileEnv = "AZURE_FEDERATED_TOKEN_FILE"
 
 const (
 	// Deprecated: The host of the Azure Active Directory (AAD) graph API
@@ -47,6 +54,56 @@ type AzureProvider struct {
 type AzureProviderConfig struct {
 	// If set to true, groups will be fetched from the Microsoft Graph API. This is supported only on Azure/Entra ID.
 	FetchGroups bool `mapstructure:"fetch_groups"`
+
+	// If set to true, the OIDC client authenticates to Microsoft Entra ID using
+	// an Azure Workload Identity federated token (client_assertion) instead of a
+	// static client secret. When enabled, oidc_client_secret must be empty and
+	// the pod must be configured for Azure Workload Identity so that the
+	// AZURE_FEDERATED_TOKEN_FILE environment variable is set.
+	UseWorkloadIdentity bool `mapstructure:"use_workload_identity"`
+}
+
+// azureWorkloadIdentityAssertion implements the oidc.JWTSerializer interface by
+// returning the Azure Workload Identity federated token. The Azure Workload
+// Identity mutating webhook projects a Kubernetes service account token into the
+// pod and sets AZURE_FEDERATED_TOKEN_FILE to its path. That token is presented
+// to Microsoft Entra ID as the client_assertion during the authorization code
+// exchange, replacing the client secret. The file is read on each call because
+// Kubernetes rotates the projected token over time.
+type azureWorkloadIdentityAssertion struct{}
+
+// Serialize returns the contents of the federated token file. It satisfies the
+// oidc.JWTSerializer interface used by oidc.WithClientAssertionJWT.
+func (azureWorkloadIdentityAssertion) Serialize() (string, error) {
+	file, ok := os.LookupEnv(azureFederatedTokenFileEnv)
+	if !ok || file == "" {
+		return "", fmt.Errorf("%s environment variable is not set; ensure the pod is configured for Azure Workload Identity (azure.workload.identity/use label and service account client-id annotation)", azureFederatedTokenFileEnv)
+	}
+
+	token, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Azure federated token file %q: %w", file, err)
+	}
+
+	return strings.TrimSpace(string(token)), nil
+}
+
+// azureWorkloadIdentityEnabled reports whether the config selects the Azure
+// provider with use_workload_identity set to true.
+func (c jwtConfig) azureWorkloadIdentityEnabled() bool {
+	if len(c.ProviderConfig) == 0 {
+		return false
+	}
+	if provider, _ := c.ProviderConfig["provider"].(string); provider != "azure" {
+		return false
+	}
+
+	var config AzureProviderConfig
+	if err := mapstructure.Decode(c.ProviderConfig, &config); err != nil {
+		return false
+	}
+
+	return config.UseWorkloadIdentity
 }
 
 // Initialize anything in the AzureProvider struct - satisfying the CustomProvider interface

--- a/provider_azure_workload_identity_test.go
+++ b/provider_azure_workload_identity_test.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package jwtauth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureWorkloadIdentityAssertion_Serialize(t *testing.T) {
+	t.Run("reads and trims the federated token file", func(t *testing.T) {
+		dir := t.TempDir()
+		tokenFile := filepath.Join(dir, "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("  federated.jwt.token\n"), 0o600))
+		t.Setenv(azureFederatedTokenFileEnv, tokenFile)
+
+		got, err := azureWorkloadIdentityAssertion{}.Serialize()
+		require.NoError(t, err)
+		require.Equal(t, "federated.jwt.token", got)
+	})
+
+	t.Run("errors when the env var is unset", func(t *testing.T) {
+		t.Setenv(azureFederatedTokenFileEnv, "")
+		_, err := azureWorkloadIdentityAssertion{}.Serialize()
+		require.Error(t, err)
+	})
+
+	t.Run("errors when the file is missing", func(t *testing.T) {
+		t.Setenv(azureFederatedTokenFileEnv, filepath.Join(t.TempDir(), "does-not-exist"))
+		_, err := azureWorkloadIdentityAssertion{}.Serialize()
+		require.Error(t, err)
+	})
+}
+
+func TestAzureWorkloadIdentityEnabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerConfig map[string]interface{}
+		want           bool
+	}{
+		{
+			name:           "nil provider config",
+			providerConfig: nil,
+			want:           false,
+		},
+		{
+			name:           "azure provider without flag",
+			providerConfig: map[string]interface{}{"provider": "azure"},
+			want:           false,
+		},
+		{
+			name:           "azure provider with flag enabled",
+			providerConfig: map[string]interface{}{"provider": "azure", "use_workload_identity": true},
+			want:           true,
+		},
+		{
+			name:           "azure provider with flag disabled",
+			providerConfig: map[string]interface{}{"provider": "azure", "use_workload_identity": false},
+			want:           false,
+		},
+		{
+			name:           "non-azure provider with flag enabled",
+			providerConfig: map[string]interface{}{"provider": "gsuite", "use_workload_identity": true},
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := jwtConfig{ProviderConfig: tt.providerConfig}
+			require.Equal(t, tt.want, c.azureWorkloadIdentityEnabled())
+		})
+	}
+}
+
+func TestAzureWorkloadIdentity_AuthTypeIsOIDCFlow(t *testing.T) {
+	// With a client ID and discovery URL but no client secret, the config would
+	// normally be classified as OIDCDiscovery. Enabling Azure workload identity
+	// must promote it to the full OIDCFlow so the login/callback paths run.
+	c := jwtConfig{
+		OIDCDiscoveryURL: "https://login.microsoftonline.com/tenant/v2.0",
+		OIDCClientID:     "client-id",
+		ProviderConfig:   map[string]interface{}{"provider": "azure", "use_workload_identity": true},
+	}
+	require.Equal(t, OIDCFlow, c.authType())
+
+	// Without the flag (and no secret) it remains plain discovery.
+	c.ProviderConfig = map[string]interface{}{"provider": "azure"}
+	require.Equal(t, OIDCDiscovery, c.authType())
+}


### PR DESCRIPTION
# Overview
Stakeholders: Vault operators who run Vault on Kubernetes (e.g. AKS) with [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/) enabled and use Microsoft Entra ID for human OIDC login to Vault.

What: Adds a `use_workload_identity` option to the OIDC auth method's Azure `provider_config`. When enabled, Vault authenticates as the OIDC relying party to Microsoft Entra ID's token endpoint using an Azure Workload Identity federated token as a `client_assertion` (RFC 7523 / `private_key_jwt` grant) during the authorization code exchange, instead of a static `oidc_client_secret`.

Why: Today the OIDC auth method's only relying-party credential is a static `oidc_client_secret`. That secret is long-lived, must be stored and rotated, and is the last static Azure credential many AKS-hosted Vault deployments cannot eliminate. Azure Workload Identity replaces it with a short-lived, automatically-rotated federated token and a federated credential on the Entra app registration — no stored secret. Argo CD already supports this exact pattern (`azure.useWorkloadIdentity`), so this brings Vault to parity.

User experience: Fully opt-in and backwards compatible. Existing `oidc_client_secret` configurations are unchanged. New users set use_workload_identity=true in provider_config and omit `oidc_client_secret`:
```
vault write auth/oidc/config \
    oidc_discovery_url="https://login.microsoftonline.com/$TENANT_ID/v2.0" \
    oidc_client_id="$CLIENT_ID" \
    provider_config='{"provider":"azure","use_workload_identity":true}'
# no oidc_client_secret
```
The Vault pod must carry the `azure.workload.identity/use` label and a service account `azure.workload.identity/client-id` annotation, and a federated credential must exist on the Entra app registration (issuer = cluster OIDC issuer, subject = Vault's service account, audience = `api://AzureADTokenExchange`).

# Design of Change
The token exchange in this plugin is delegated to `github.com/hashicorp/cap/oidc`, which since v0.11.0 supports injecting a client assertion via the request option `oidc.WithClientAssertionJWT(JWTSerializer)` (`Provider.Exchange` then sends `client_assertion_type` + `client_assertion` and tolerates an empty `ClientSecret`). The plugin already pins cap v0.13.0, so no dependency change is required.

Implementation:

- `provider_azure.go`
  - Added `UseWorkloadIdentity bool` (`mapstructure:"use_workload_identity"`) to `AzureProviderConfig`.
  - Added `azureWorkloadIdentityAssertion`, an `oidc.JWTSerializer` whose `Serialize()` reads and trims the federated token from `AZURE_FEDERATED_TOKEN_FILE` (read per-exchange, since Kubernetes rotates the projected token).
  - Added `jwtConfig.azureWorkloadIdentityEnabled()` to detect the Azure provider + flag.
- `path_oidc.go` — in `createOIDCRequest`, when the flag is set, append `oidc.WithClientAssertionJWT(azureWorkloadIdentityAssertion{})` to the request options.
- `path_config.go` — `authType()` now classifies a config with `oidc_client_id` + discovery URL and workload identity enabled (no secret) as `OIDCFlow`; config validation requires `oidc_client_id`, rejects a non-empty `oidc_client_secret`, and runs provider construction when the flag is set.
- Tests (`provider_azure_workload_identity_test.go`) — cover the serializer (read/trim, unset env var, missing file), the detector (5 cases incl. non-Azure provider), and the authType promotion.

The seam is cap's `JWTSerializer` interface, so additional assertion sources (e.g. a generic `private_key_jwt` signing key) can be added later as new serializers without reworking this path.

# Related Issues/Pull Requests
Closes #405
 (Searched hashicorp/vault-plugin-auth-jwt; none found for OIDC client assertion / workload identity.)
Prior art: [Argo CD's Azure Workload Identity OIDC login](https://github.com/argoproj/argo-cd/blob/master/util/oidc/oidc.go) (useAzureWorkloadIdentity).
Enabling capability: [hashicorp/cap#155 — OIDC private key JWT / client assertion](https://github.com/hashicorp/cap/pull/155).

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
```
=== RUN   TestAzureWorkloadIdentityAssertion_Serialize
--- PASS: TestAzureWorkloadIdentityAssertion_Serialize (0.00s)
=== RUN   TestAzureWorkloadIdentityEnabled
--- PASS: TestAzureWorkloadIdentityEnabled (0.00s)
=== RUN   TestAzureWorkloadIdentity_AuthTypeIsOIDCFlow
--- PASS: TestAzureWorkloadIdentity_AuthTypeIsOIDCFlow (0.00s)
PASS
ok  github.com/hashicorp/vault-plugin-auth-jwt  0.537s
```
- [x] Backwards compatible
Opt-in flag. The `oidc_client_secret` path and all existing configs are unchanged; with the flag unset, behavior is identical to before. No storage/schema migration.
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
