### PR TITLE
[CHANGELOG] Prepare for v0.26.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.26.4
+### September 3, 2026
+
+* updated go version (#409)
+* preapre v0.26.4 release (#408)
+* manual backport of okta groups fetching feature (#407)
+
 ## Unreleased
 
 FEATURES:


### PR DESCRIPTION
Changelog update for version [v0.26.4](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.26.4).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/33750917732

